### PR TITLE
Fix TypeScript JSX namespace error in HelpPanel

### DIFF
--- a/src/components/HelpPanel.tsx
+++ b/src/components/HelpPanel.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
+import type { JSX } from 'react'
 import { useTransactionStore } from '../stores/transactionStore'
 import { getHelpContent, HelpContext } from '../utils/helpContent'
 


### PR DESCRIPTION
Add missing JSX type import from React to resolve TS2503 error. React 19 with new JSX transform requires explicit JSX type import.

Fixes build error: "Cannot find namespace 'JSX'" at line 242