### PR TITLE
Add support for short selling

### DIFF
--- a/public/examples/schwab-transactions-example.csv
+++ b/public/examples/schwab-transactions-example.csv
@@ -1,6 +1,8 @@
-"Date","Action","Symbol","Description","Quantity","Price","Fees & Comm","Amount"
-"01/15/2024","Buy","AAPL","APPLE INC","10","$150.00","$0.00","-$1,500.00"
-"02/20/2024","Sell","AAPL","APPLE INC","5","$160.00","$0.00","$800.00"
-"03/10/2024","Buy","MSFT","MICROSOFT CORP","15","$350.00","$0.00","-$5,250.00"
-"04/05/2024","Dividend","AAPL","APPLE INC DIVIDEND","","","","$12.50"
-"05/12/2024","Sell","MSFT","MICROSOFT CORP","10","$370.00","$1.00","$3,699.00"
+Date,Action,Symbol,Description,Quantity,Price,Fees & Comm,Amount
+01/15/2024,Buy,AAPL,APPLE INC,10,$150.00,$0.00,"-$1,500.00"
+02/20/2024,Sell,AAPL,APPLE INC,5,$160.00,$0.00,$800.00
+03/10/2024,Buy,MSFT,MICROSOFT CORP,15,$350.00,$0.00,"-$5,250.00"
+04/05/2024,Dividend,AAPL,APPLE INC DIVIDEND,,,,$12.50
+05/12/2024,Sell,MSFT,MICROSOFT CORP,10,$370.00,$1.00,"$3,699.00"
+07/26/2023,Buy,SNAP,SNAP INC CLASS A,100,$10.075,,-$1007.50
+07/25/2023,Sell Short,SNAP,SNAP INC CLASS A,100,$12.50,$0.02,$1249.98

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -415,6 +415,21 @@ export function TransactionList() {
                           label: '30-Day',
                           title: tooltip
                         })
+                      } else if (matching.rule === 'SHORT_SELL') {
+                        const quantityMatched = matching.quantityMatched
+                        const hasSplit = tx.split_multiplier && tx.split_multiplier !== 1.0
+                        let tooltip: string
+                        if (hasSplit && tx.split_multiplier) {
+                          const originalMatched = quantityMatched / tx.split_multiplier
+                          tooltip = `Short Sell: ${originalMatched.toFixed(2)} shares (${quantityMatched.toFixed(2)} split-adjusted) sold short and covered by subsequent purchase`
+                        } else {
+                          tooltip = `Short Sell: ${quantityMatched.toFixed(2)} shares sold short and covered by subsequent purchase`
+                        }
+                        badges.push({
+                          className: 'bg-pink-100 text-pink-800 border-pink-300',
+                          label: 'Short Sell',
+                          title: tooltip
+                        })
                       } else if (matching.rule === 'SECTION_104' && matching.quantityMatched > 0) {
                         // Only show Section 104 badge if some quantity was actually matched
                         const quantityMatched = matching.quantityMatched
@@ -486,6 +501,19 @@ export function TransactionList() {
                       badges.push({
                         className: 'bg-orange-100 text-orange-800 border-orange-300',
                         label: '30-Day',
+                        title: tooltip
+                      })
+                    } else if (rule === 'SHORT_SELL') {
+                      let tooltip: string
+                      if (hasSplit && tx.split_multiplier) {
+                        const originalQty = qty / tx.split_multiplier
+                        tooltip = `Short Sell: ${originalQty.toFixed(2)} shares (${qty.toFixed(2)} split-adjusted) used to cover a short sell`
+                      } else {
+                        tooltip = `Short Sell: ${qty.toFixed(2)} shares used to cover a short sell`
+                      }
+                      badges.push({
+                        className: 'bg-pink-100 text-pink-800 border-pink-300',
+                        label: 'Short Sell',
                         title: tooltip
                       })
                     }

--- a/src/lib/cgt/__tests__/engine.test.ts
+++ b/src/lib/cgt/__tests__/engine.test.ts
@@ -61,7 +61,34 @@ describe('CGT Engine', () => {
     })
 
     it('should apply 30-day rule after same-day', () => {
+      // To test 30-day rule, we need a scenario where:
+      // 1. Shares are owned (via prior BUY)
+      // 2. SELL happens (normal disposal, not short sell)
+      // 3. BUY happens within 30 days after the SELL
+      // The 30-day rule should match the SELL with the subsequent BUY
       const transactions: EnrichedTransaction[] = [
+        {
+          id: 'tx-0',
+          source: 'test',
+          symbol: 'AAPL',
+          name: 'Apple Inc.',
+          date: '2023-05-01',
+          type: 'BUY',
+          quantity: 10,
+          price: 170,
+          currency: 'USD',
+          total: 1700,
+          fee: 5,
+          notes: null,
+          fx_rate: 1.27,
+          price_gbp: 133.86,
+          value_gbp: 1338.58,
+          fee_gbp: 3.94,
+          fx_source: 'HMRC',
+          fx_error: null,
+          tax_year: '2023/24',
+          gain_group: 'NONE',
+        },
         {
           id: 'tx-1',
           source: 'test',
@@ -110,8 +137,9 @@ describe('CGT Engine', () => {
 
       const result = calculateCGT(transactions)
 
-      expect(result.transactions[0].gain_group).toBe('30_DAY')
+      // tx-1 (SELL) should be matched with tx-2 (BUY) under 30-day rule
       expect(result.transactions[1].gain_group).toBe('30_DAY')
+      expect(result.transactions[2].gain_group).toBe('30_DAY')
       expect(result.disposals).toHaveLength(1)
       expect(result.disposals[0].matchings[0].rule).toBe('30_DAY')
     })

--- a/src/lib/cgt/__tests__/shortSellMatcher.test.ts
+++ b/src/lib/cgt/__tests__/shortSellMatcher.test.ts
@@ -1,0 +1,388 @@
+import { describe, it, expect } from 'vitest'
+import { applyShortSellRule, markShortSellMatches, getRemainingQuantity } from '../shortSellMatcher'
+import { EnrichedTransaction } from '../../../types/transaction'
+
+/**
+ * Helper to create a test transaction
+ */
+function createTransaction(
+  overrides: Partial<EnrichedTransaction> & { id: string; date: string; type: 'BUY' | 'SELL'; quantity: number }
+): EnrichedTransaction {
+  return {
+    source: 'test',
+    symbol: 'AAPL',
+    name: 'Apple Inc.',
+    currency: 'USD',
+    total: overrides.quantity * (overrides.price || 100),
+    fee: 5,
+    notes: null,
+    fx_rate: 1.27,
+    price: overrides.price || 100,
+    price_gbp: (overrides.price || 100) / 1.27,
+    value_gbp: (overrides.quantity * (overrides.price || 100)) / 1.27,
+    fee_gbp: 3.94,
+    fx_source: 'HMRC',
+    fx_error: null,
+    tax_year: '2023/24',
+    gain_group: 'NONE',
+    ...overrides,
+  }
+}
+
+describe('Short Sell Matcher', () => {
+  describe('applyShortSellRule', () => {
+    it('should match an explicit short sell (is_short_sell: true) with subsequent BUY', () => {
+      const transactions: EnrichedTransaction[] = [
+        createTransaction({ id: 'sell-1', date: '2023-06-01', type: 'SELL', quantity: 100, price: 150, is_short_sell: true }),
+        createTransaction({ id: 'buy-1', date: '2023-06-15', type: 'BUY', quantity: 100, price: 140 }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+
+      expect(matchings).toHaveLength(1)
+      expect(matchings[0].rule).toBe('SHORT_SELL')
+      expect(matchings[0].disposal.id).toBe('sell-1')
+      expect(matchings[0].acquisitions).toHaveLength(1)
+      expect(matchings[0].acquisitions[0].transaction.id).toBe('buy-1')
+      expect(matchings[0].quantityMatched).toBe(100)
+    })
+
+    /**
+     * EDUCATIONAL: This scenario is invalid for Schwab users.
+     * Schwab requires explicit opt-in for short selling, so a SELL cannot occur
+     * before a BUY unless it's marked as a short sell. This test documents the
+     * expected behavior if such invalid data were to occur.
+     */
+    it.skip('should NOT match sells without is_short_sell flag (invalid scenario - educational only)', () => {
+      const transactions: EnrichedTransaction[] = [
+        // SELL before BUY, but no is_short_sell flag - should NOT be matched
+        // NOTE: This scenario cannot happen with Schwab - they require explicit short sell opt-in
+        createTransaction({ id: 'sell-1', date: '2023-06-01', type: 'SELL', quantity: 100, price: 150 }),
+        createTransaction({ id: 'buy-1', date: '2023-06-15', type: 'BUY', quantity: 100, price: 140 }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+
+      // No short sell matches - is_short_sell flag is required
+      expect(matchings).toHaveLength(0)
+    })
+
+    it('should not match normal trades (BUY before SELL without flag)', () => {
+      const transactions: EnrichedTransaction[] = [
+        createTransaction({ id: 'buy-1', date: '2023-06-01', type: 'BUY', quantity: 100, price: 140 }),
+        createTransaction({ id: 'sell-1', date: '2023-06-15', type: 'SELL', quantity: 100, price: 150 }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+
+      // No short sell matches - this is a normal trade
+      expect(matchings).toHaveLength(0)
+    })
+
+    it('should match multiple explicit short sells with a single BUY (FIFO)', () => {
+      const transactions: EnrichedTransaction[] = [
+        createTransaction({ id: 'sell-1', date: '2023-06-01', type: 'SELL', quantity: 50, price: 160, is_short_sell: true }),
+        createTransaction({ id: 'sell-2', date: '2023-06-02', type: 'SELL', quantity: 30, price: 155, is_short_sell: true }),
+        createTransaction({ id: 'buy-1', date: '2023-06-15', type: 'BUY', quantity: 80, price: 140 }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+
+      // Should have 2 matchings - one for each short sell
+      expect(matchings).toHaveLength(2)
+
+      // First short sell (sell-1) matched first (FIFO)
+      expect(matchings[0].disposal.id).toBe('sell-1')
+      expect(matchings[0].quantityMatched).toBe(50)
+      expect(matchings[0].acquisitions[0].transaction.id).toBe('buy-1')
+
+      // Second short sell (sell-2) matched next
+      expect(matchings[1].disposal.id).toBe('sell-2')
+      expect(matchings[1].quantityMatched).toBe(30)
+      expect(matchings[1].acquisitions[0].transaction.id).toBe('buy-1')
+    })
+
+    it('should match single explicit short sell with multiple BUYs', () => {
+      const transactions: EnrichedTransaction[] = [
+        createTransaction({ id: 'sell-1', date: '2023-06-01', type: 'SELL', quantity: 100, price: 160, is_short_sell: true }),
+        createTransaction({ id: 'buy-1', date: '2023-06-15', type: 'BUY', quantity: 40, price: 140 }),
+        createTransaction({ id: 'buy-2', date: '2023-06-20', type: 'BUY', quantity: 60, price: 145 }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+
+      // Should have 2 matchings for the same disposal (matched with 2 different BUYs)
+      expect(matchings).toHaveLength(2)
+
+      // Both matchings should be for sell-1
+      expect(matchings[0].disposal.id).toBe('sell-1')
+      expect(matchings[1].disposal.id).toBe('sell-1')
+
+      // First matching with buy-1 for 40 shares
+      expect(matchings[0].acquisitions[0].transaction.id).toBe('buy-1')
+      expect(matchings[0].quantityMatched).toBe(40)
+
+      // Second matching with buy-2 for 60 shares
+      expect(matchings[1].acquisitions[0].transaction.id).toBe('buy-2')
+      expect(matchings[1].quantityMatched).toBe(60)
+    })
+
+    it('should handle partial covering (some short positions remain uncovered)', () => {
+      const transactions: EnrichedTransaction[] = [
+        createTransaction({ id: 'sell-1', date: '2023-06-01', type: 'SELL', quantity: 100, price: 160, is_short_sell: true }),
+        createTransaction({ id: 'buy-1', date: '2023-06-15', type: 'BUY', quantity: 60, price: 140 }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+
+      // Only 60 shares matched, 40 remain uncovered
+      expect(matchings).toHaveLength(1)
+      expect(matchings[0].quantityMatched).toBe(60)
+    })
+
+    it('should only match short sell quantity when BUY quantity exceeds short sell (excess goes to Section 104)', () => {
+      const transactions: EnrichedTransaction[] = [
+        createTransaction({ id: 'sell-1', date: '2023-06-01', type: 'SELL', quantity: 50, price: 160, is_short_sell: true }),
+        createTransaction({ id: 'buy-1', date: '2023-06-15', type: 'BUY', quantity: 100, price: 140 }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+
+      // Only 50 shares matched (the short sell quantity)
+      // The remaining 50 shares from BUY are NOT matched here - they go to Section 104 pool
+      expect(matchings).toHaveLength(1)
+      expect(matchings[0].disposal.id).toBe('sell-1')
+      expect(matchings[0].quantityMatched).toBe(50)
+      expect(matchings[0].acquisitions[0].transaction.id).toBe('buy-1')
+      expect(matchings[0].acquisitions[0].quantityMatched).toBe(50)
+
+      // Verify remaining quantity on the BUY transaction
+      const buyRemaining = getRemainingQuantity(transactions[1], matchings)
+      expect(buyRemaining).toBe(50) // 100 - 50 = 50 shares available for Section 104
+    })
+
+    it('should handle different symbols independently', () => {
+      const transactions: EnrichedTransaction[] = [
+        createTransaction({ id: 'sell-aapl', date: '2023-06-01', type: 'SELL', quantity: 50, price: 160, symbol: 'AAPL', is_short_sell: true }),
+        createTransaction({ id: 'sell-googl', date: '2023-06-02', type: 'SELL', quantity: 30, price: 100, symbol: 'GOOGL', is_short_sell: true }),
+        createTransaction({ id: 'buy-aapl', date: '2023-06-15', type: 'BUY', quantity: 50, price: 140, symbol: 'AAPL' }),
+        // No BUY for GOOGL - should remain uncovered
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+
+      // Only AAPL should have a match
+      expect(matchings).toHaveLength(1)
+      expect(matchings[0].disposal.symbol).toBe('AAPL')
+      expect(matchings[0].quantityMatched).toBe(50)
+    })
+
+    it('should calculate correct cost basis from covering BUY', () => {
+      const transactions: EnrichedTransaction[] = [
+        createTransaction({ id: 'sell-1', date: '2023-06-01', type: 'SELL', quantity: 100, price: 160, price_gbp: 126, is_short_sell: true }),
+        createTransaction({
+          id: 'buy-1',
+          date: '2023-06-15',
+          type: 'BUY',
+          quantity: 100,
+          price: 140,
+          price_gbp: 110.24,
+          fee_gbp: 5,
+        }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+
+      expect(matchings).toHaveLength(1)
+      // Cost basis = (price per share + fee per share) * quantity matched
+      // = (110.24 + 5/100) * 100 = (110.24 + 0.05) * 100 = 110.29 * 100 = 11029
+      expect(matchings[0].totalCostBasisGbp).toBeCloseTo(11029, 0)
+    })
+
+    it('should match explicit short sell alongside normal trades', () => {
+      const transactions: EnrichedTransaction[] = [
+        // Normal trade: BUY first, SELL later (no flag) - this is a regular long position
+        createTransaction({ id: 'buy-1', date: '2023-05-01', type: 'BUY', quantity: 100, price: 140 }),
+        createTransaction({ id: 'sell-1', date: '2023-05-15', type: 'SELL', quantity: 50, price: 150 }),
+        // Explicit short sell with flag - user opted into short selling
+        createTransaction({ id: 'sell-2', date: '2023-06-01', type: 'SELL', quantity: 80, price: 160, is_short_sell: true }),
+        // Cover the short
+        createTransaction({ id: 'buy-2', date: '2023-06-15', type: 'BUY', quantity: 80, price: 145 }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+
+      // Only the explicit short sell (sell-2) should be matched by this rule
+      // The normal trade (buy-1/sell-1) will be matched by Section 104 pool rules
+      expect(matchings).toHaveLength(1)
+      expect(matchings[0].disposal.id).toBe('sell-2')
+      expect(matchings[0].quantityMatched).toBe(80)
+      expect(matchings[0].acquisitions[0].transaction.id).toBe('buy-2')
+    })
+
+    it('should process transactions in chronological order regardless of input order', () => {
+      const transactions: EnrichedTransaction[] = [
+        // Input in wrong order
+        createTransaction({ id: 'buy-1', date: '2023-06-15', type: 'BUY', quantity: 100, price: 140 }),
+        createTransaction({ id: 'sell-1', date: '2023-06-01', type: 'SELL', quantity: 100, price: 160, is_short_sell: true }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+
+      // Short sell should still be matched with the BUY
+      expect(matchings).toHaveLength(1)
+      expect(matchings[0].disposal.id).toBe('sell-1')
+    })
+
+    it('should handle empty transactions', () => {
+      const matchings = applyShortSellRule([])
+      expect(matchings).toHaveLength(0)
+    })
+
+    it('should handle transactions with only BUYs', () => {
+      const transactions: EnrichedTransaction[] = [
+        createTransaction({ id: 'buy-1', date: '2023-06-01', type: 'BUY', quantity: 100, price: 140 }),
+        createTransaction({ id: 'buy-2', date: '2023-06-15', type: 'BUY', quantity: 50, price: 145 }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+      expect(matchings).toHaveLength(0)
+    })
+
+    it('should use split-adjusted quantities when available', () => {
+      const transactions: EnrichedTransaction[] = [
+        createTransaction({
+          id: 'sell-1',
+          date: '2023-06-01',
+          type: 'SELL',
+          quantity: 10,
+          split_adjusted_quantity: 100, // After a 10:1 split
+          price: 1600,
+          is_short_sell: true,
+        }),
+        createTransaction({
+          id: 'buy-1',
+          date: '2023-06-15',
+          type: 'BUY',
+          quantity: 100,
+          split_adjusted_quantity: 100,
+          price: 140,
+        }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+
+      expect(matchings).toHaveLength(1)
+      expect(matchings[0].quantityMatched).toBe(100) // Uses split-adjusted quantity
+    })
+
+    it('should not match BUYs that occur before short sells', () => {
+      const transactions: EnrichedTransaction[] = [
+        createTransaction({ id: 'buy-1', date: '2023-06-01', type: 'BUY', quantity: 100, price: 140 }),
+        createTransaction({ id: 'sell-1', date: '2023-06-15', type: 'SELL', quantity: 100, price: 160, is_short_sell: true }),
+        createTransaction({ id: 'buy-2', date: '2023-06-20', type: 'BUY', quantity: 100, price: 150 }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+
+      // Only buy-2 should match (comes after the short sell)
+      expect(matchings).toHaveLength(1)
+      expect(matchings[0].disposal.id).toBe('sell-1')
+      expect(matchings[0].acquisitions[0].transaction.id).toBe('buy-2')
+      expect(matchings[0].quantityMatched).toBe(100)
+    })
+  })
+
+  describe('markShortSellMatches', () => {
+    it('should mark matched transactions with SHORT_SELL gain group', () => {
+      const transactions: EnrichedTransaction[] = [
+        createTransaction({ id: 'sell-1', date: '2023-06-01', type: 'SELL', quantity: 100, price: 160, is_short_sell: true }),
+        createTransaction({ id: 'buy-1', date: '2023-06-15', type: 'BUY', quantity: 100, price: 140 }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+      const marked = markShortSellMatches(transactions, matchings)
+
+      expect(marked[0].gain_group).toBe('SHORT_SELL')
+      expect(marked[1].gain_group).toBe('SHORT_SELL')
+    })
+
+    it('should not mark normal long trades (matched by other rules)', () => {
+      const transactions: EnrichedTransaction[] = [
+        // Normal long trade: BUY first, then SELL from existing position
+        createTransaction({ id: 'buy-1', date: '2023-06-01', type: 'BUY', quantity: 100, price: 140 }),
+        createTransaction({ id: 'sell-1', date: '2023-06-15', type: 'SELL', quantity: 100, price: 150 }),
+      ]
+
+      const matchings = applyShortSellRule(transactions)
+      const marked = markShortSellMatches(transactions, matchings)
+
+      // Normal trade - should remain NONE (will be matched by Section 104 pool rules)
+      expect(marked[0].gain_group).toBe('NONE')
+      expect(marked[1].gain_group).toBe('NONE')
+    })
+  })
+
+  describe('getRemainingQuantity', () => {
+    it('should return original quantity when no matchings exist', () => {
+      const transaction = createTransaction({ id: 'sell-1', date: '2023-06-01', type: 'SELL', quantity: 100, price: 160, is_short_sell: true })
+
+      const remaining = getRemainingQuantity(transaction, [])
+      expect(remaining).toBe(100)
+    })
+
+    it('should return 0 when fully matched as disposal', () => {
+      const disposal = createTransaction({ id: 'sell-1', date: '2023-06-01', type: 'SELL', quantity: 100, price: 160, is_short_sell: true })
+      const acquisition = createTransaction({ id: 'buy-1', date: '2023-06-15', type: 'BUY', quantity: 100, price: 140 })
+
+      const matchings = [
+        {
+          disposal,
+          acquisitions: [{ transaction: acquisition, quantityMatched: 100, costBasisGbp: 14000 }],
+          rule: 'SHORT_SELL' as const,
+          quantityMatched: 100,
+          totalCostBasisGbp: 14000,
+        },
+      ]
+
+      const remaining = getRemainingQuantity(disposal, matchings)
+      expect(remaining).toBe(0)
+    })
+
+    it('should return remaining quantity for partial matches', () => {
+      const disposal = createTransaction({ id: 'sell-1', date: '2023-06-01', type: 'SELL', quantity: 100, price: 160, is_short_sell: true })
+      const acquisition = createTransaction({ id: 'buy-1', date: '2023-06-15', type: 'BUY', quantity: 60, price: 140 })
+
+      const matchings = [
+        {
+          disposal,
+          acquisitions: [{ transaction: acquisition, quantityMatched: 60, costBasisGbp: 8400 }],
+          rule: 'SHORT_SELL' as const,
+          quantityMatched: 60,
+          totalCostBasisGbp: 8400,
+        },
+      ]
+
+      const remaining = getRemainingQuantity(disposal, matchings)
+      expect(remaining).toBe(40)
+    })
+
+    it('should return 0 when fully matched as acquisition', () => {
+      const disposal = createTransaction({ id: 'sell-1', date: '2023-06-01', type: 'SELL', quantity: 100, price: 160, is_short_sell: true })
+      const acquisition = createTransaction({ id: 'buy-1', date: '2023-06-15', type: 'BUY', quantity: 100, price: 140 })
+
+      const matchings = [
+        {
+          disposal,
+          acquisitions: [{ transaction: acquisition, quantityMatched: 100, costBasisGbp: 14000 }],
+          rule: 'SHORT_SELL' as const,
+          quantityMatched: 100,
+          totalCostBasisGbp: 14000,
+        },
+      ]
+
+      const remaining = getRemainingQuantity(acquisition, matchings)
+      expect(remaining).toBe(0)
+    })
+  })
+})

--- a/src/lib/cgt/shortSellMatcher.ts
+++ b/src/lib/cgt/shortSellMatcher.ts
@@ -1,0 +1,207 @@
+import { EnrichedTransaction, TransactionType } from '../../types/transaction'
+import { MatchingResult } from '../../types/cgt'
+import { getEffectiveQuantity, getEffectivePrice } from './utils'
+
+/**
+ * Short Sell Matching Rule
+ *
+ * Short selling is when you sell shares you don't own, betting the price will fall.
+ * You later buy shares to "cover" the short position.
+ *
+ * This matcher identifies short sells using the explicit `is_short_sell` flag
+ * set by broker parsers (e.g., Schwab "Sell Short" action).
+ *
+ * Key points:
+ * - Only transactions with `is_short_sell: true` are treated as short sells
+ * - Short positions are matched against subsequent BUYs using FIFO
+ * - The SELL is the disposal, the covering BUY is the acquisition
+ * - Gain = SELL proceeds - BUY cost (profit if sold high, bought low)
+ *
+ * This rule runs BEFORE same-day, 30-day, and Section 104 rules.
+ */
+
+/**
+ * Represents an open short position waiting to be covered
+ */
+interface ShortPosition {
+  /** The original SELL transaction that opened the short */
+  transaction: EnrichedTransaction
+  /** Remaining quantity that hasn't been covered yet */
+  remainingQuantity: number
+}
+
+/**
+ * Apply short sell matching rule to transactions
+ *
+ * Identifies short sells using the explicit `is_short_sell` flag and matches
+ * them against subsequent BUY transactions to cover the position.
+ *
+ * @param transactions All enriched transactions
+ * @returns Array of matching results for short sell matches
+ */
+export function applyShortSellRule(
+  transactions: EnrichedTransaction[]
+): MatchingResult[] {
+  const matchings: MatchingResult[] = []
+
+  // Group by symbol
+  const bySymbol = groupBySymbol(transactions)
+
+  for (const symbolTransactions of bySymbol.values()) {
+    // Sort chronologically
+    const sorted = symbolTransactions.sort((a, b) => a.date.localeCompare(b.date))
+
+    // Queue of open short positions (FIFO)
+    const shortPositions: ShortPosition[] = []
+
+    // Process each transaction in chronological order
+    for (const tx of sorted) {
+      const quantity = getEffectiveQuantity(tx)
+      if (quantity <= 0) continue
+
+      if (tx.type === TransactionType.SELL && tx.is_short_sell) {
+        // This is an explicit short sell - add to short positions queue
+        shortPositions.push({
+          transaction: tx,
+          remainingQuantity: quantity,
+        })
+      } else if (tx.type === TransactionType.BUY && shortPositions.length > 0) {
+        // BUY can cover open short positions
+        let remainingBuyQuantity = quantity
+
+        while (shortPositions.length > 0 && remainingBuyQuantity > 0) {
+          const oldestShort = shortPositions[0]
+          const quantityToMatch = Math.min(remainingBuyQuantity, oldestShort.remainingQuantity)
+
+          // Create matching result: SELL (disposal) matched with BUY (acquisition)
+          const matching = createShortSellMatching(
+            oldestShort.transaction,
+            tx,
+            quantityToMatch
+          )
+          matchings.push(matching)
+
+          // Update quantities
+          remainingBuyQuantity -= quantityToMatch
+          oldestShort.remainingQuantity -= quantityToMatch
+
+          // Remove fully covered short positions
+          if (oldestShort.remainingQuantity <= 0) {
+            shortPositions.shift()
+          }
+        }
+      }
+    }
+  }
+
+  return matchings
+}
+
+/**
+ * Create a matching result for a short sell
+ *
+ * @param disposal The SELL transaction (opening the short)
+ * @param acquisition The BUY transaction (covering the short)
+ * @param quantity The quantity matched
+ */
+function createShortSellMatching(
+  disposal: EnrichedTransaction,
+  acquisition: EnrichedTransaction,
+  quantity: number
+): MatchingResult {
+  // Calculate cost basis for the covering BUY
+  const buyPricePerShare = getEffectivePrice(acquisition)
+  const buyEffectiveQuantity = getEffectiveQuantity(acquisition)
+  const buyFeePerShare = acquisition.fee_gbp
+    ? acquisition.fee_gbp / Math.max(buyEffectiveQuantity, 1)
+    : 0
+  const costBasisPerShare = buyPricePerShare + buyFeePerShare
+  const costBasisGbp = costBasisPerShare * quantity
+
+  return {
+    disposal,
+    acquisitions: [
+      {
+        transaction: acquisition,
+        quantityMatched: quantity,
+        costBasisGbp,
+      },
+    ],
+    rule: 'SHORT_SELL',
+    quantityMatched: quantity,
+    totalCostBasisGbp: costBasisGbp,
+  }
+}
+
+/**
+ * Mark transactions as matched under short sell rule
+ */
+export function markShortSellMatches(
+  transactions: EnrichedTransaction[],
+  matchings: MatchingResult[]
+): EnrichedTransaction[] {
+  const matchedTxIds = new Set<string>()
+
+  // Collect all transaction IDs involved in short sell matches
+  for (const matching of matchings) {
+    matchedTxIds.add(matching.disposal.id)
+    for (const acq of matching.acquisitions) {
+      matchedTxIds.add(acq.transaction.id)
+    }
+  }
+
+  // Update gain_group for matched transactions
+  return transactions.map(tx => {
+    if (matchedTxIds.has(tx.id)) {
+      return { ...tx, gain_group: 'SHORT_SELL' }
+    }
+    return tx
+  })
+}
+
+/**
+ * Get remaining unmatched quantity for a transaction after short sell matching
+ */
+export function getRemainingQuantity(
+  transaction: EnrichedTransaction,
+  matchings: MatchingResult[]
+): number {
+  const originalQuantity = getEffectiveQuantity(transaction)
+
+  // Sum up all matched quantities for this transaction
+  let matchedQuantity = 0
+
+  for (const matching of matchings) {
+    // Check if this transaction is the disposal
+    if (matching.disposal.id === transaction.id) {
+      matchedQuantity += matching.quantityMatched
+    }
+
+    // Check if this transaction is an acquisition
+    for (const acq of matching.acquisitions) {
+      if (acq.transaction.id === transaction.id) {
+        matchedQuantity += acq.quantityMatched
+      }
+    }
+  }
+
+  return Math.max(0, originalQuantity - matchedQuantity)
+}
+
+/**
+ * Group transactions by symbol
+ */
+function groupBySymbol(
+  transactions: EnrichedTransaction[]
+): Map<string, EnrichedTransaction[]> {
+  const groups = new Map<string, EnrichedTransaction[]>()
+
+  for (const tx of transactions) {
+    if (!groups.has(tx.symbol)) {
+      groups.set(tx.symbol, [])
+    }
+    groups.get(tx.symbol)!.push(tx)
+  }
+
+  return groups
+}

--- a/src/lib/parsers/__tests__/schwab.test.ts
+++ b/src/lib/parsers/__tests__/schwab.test.ts
@@ -58,6 +58,53 @@ describe('Schwab Parser', () => {
       expect(result[0].price).toBe(175.50)
     })
 
+    it('should normalize a Sell Short transaction with is_short_sell flag', () => {
+      const rows = [
+        {
+          'Date': '07/25/2023',
+          'Action': 'Sell Short',
+          'Symbol': 'SNAP',
+          'Description': 'SNAP INC CLASS A',
+          'Quantity': '100',
+          'Price': '$12.50',
+          'Fees & Comm': '$0.02',
+          'Amount': '$1249.98',
+        },
+      ]
+
+      const result = normalizeSchwabTransactions(rows, 'test-file')
+
+      expect(result).toHaveLength(1)
+      expect(result[0].type).toBe(TransactionType.SELL)
+      expect(result[0].symbol).toBe('SNAP')
+      expect(result[0].quantity).toBe(100)
+      expect(result[0].price).toBe(12.50)
+      expect(result[0].fee).toBe(0.02)
+      expect(result[0].total).toBe(1249.98)
+      expect(result[0].is_short_sell).toBe(true)
+    })
+
+    it('should not set is_short_sell for regular Sell transactions', () => {
+      const rows = [
+        {
+          'Date': '08/15/2024',
+          'Action': 'Sell',
+          'Symbol': 'AAPL',
+          'Description': 'APPLE INC',
+          'Quantity': '50',
+          'Price': '175.50',
+          'Fees & Comm': '$0.02',
+          'Amount': '$8774.98',
+        },
+      ]
+
+      const result = normalizeSchwabTransactions(rows, 'test-file')
+
+      expect(result).toHaveLength(1)
+      expect(result[0].type).toBe(TransactionType.SELL)
+      expect(result[0].is_short_sell).toBeUndefined()
+    })
+
     it('should normalize dividend transactions', () => {
       const rows = [
         {

--- a/src/types/transaction.ts
+++ b/src/types/transaction.ts
@@ -20,6 +20,7 @@ export const GenericTransactionSchema = z.object({
   ratio: z.string().nullable().optional().describe('Stock split ratio (e.g., "10:1", "2:1", "1:10"). Only used for STOCK_SPLIT transactions.'),
   incomplete: z.boolean().optional().describe('True if transaction is missing required data (e.g., Stock Plan Activity without price)'),
   ignored: z.boolean().optional().describe('True if transaction should be excluded from calculations (e.g., Stock Plan Activity which is always incomplete)'),
+  is_short_sell: z.boolean().optional().describe('True if this is an explicit short sell as reported by the broker (e.g., Schwab "Sell Short" action)'),
   imported_at: z.string().optional().describe('ISO timestamp when transaction was imported (e.g., 2024-01-15T10:30:00.000Z)'),
 })
 
@@ -46,7 +47,7 @@ export const EnrichedTransactionSchema = GenericTransactionSchema.extend({
 
   // Tax year and CGT matching (computed during enrichment, Step 3)
   tax_year: z.string().describe('UK tax year (e.g. 2023/24)'),
-  gain_group: z.enum(['SAME_DAY', '30_DAY', 'SECTION_104', 'NONE']).describe('HMRC matching rule applied'),
+  gain_group: z.enum(['SAME_DAY', '30_DAY', 'SECTION_104', 'SHORT_SELL', 'NONE']).describe('HMRC matching rule applied'),
   match_groups: z.array(z.string()).optional().describe('Array of match group IDs this transaction belongs to. A single acquisition can match multiple disposals, so this is an array.'),
 })
 
@@ -73,6 +74,7 @@ export const GainGroup = {
   SAME_DAY: 'SAME_DAY',
   THIRTY_DAY: '30_DAY',
   SECTION_104: 'SECTION_104',
+  SHORT_SELL: 'SHORT_SELL',
   NONE: 'NONE',
 } as const
 


### PR DESCRIPTION
## Goal
Add support for short selling where disposal (SELL) happens before acquisition (BUY). Infer short sells from chronological order - when a SELL occurs without sufficient prior BUYs, it's a short sell. Use FIFO matching to pair short sales with their covering buys.

## Key Design Decisions
- [ ] Infer short selling from transaction order: SELL with no prior unmatched BUYs = short sell
- [ ] Create a separate `shortSellMatcher.ts` that runs BEFORE the regular matching rules
- [ ] Add a new gain group `SHORT_SELL` to track short sell matches
- [ ] Match using FIFO: oldest uncovered SELL matched with earliest subsequent BUY

**Algorithm:**
```
For each symbol:
  available_shares = 0
  short_positions = []  # Queue of (sell_tx, remaining_qty)
  
  For each transaction (chronologically):
    if BUY:
      # First, cover any open short positions
      while short_positions not empty AND quantity > 0:
        match oldest short with this buy
        create MatchingResult
      # Remaining buy quantity adds to available shares
      available_shares += remaining_quantity
    
    if SELL:
      if sell_quantity <= available_shares:
        # Normal sell - let other matchers handle it
        available_shares -= sell_quantity
      else:
        # Short sell - quantity exceeds available
        short_quantity = sell_quantity - available_shares
        available_shares = 0
        short_positions.append((sell_tx, short_quantity))
```

The order becomes:
1. **Short Sell Rule** (new) - Match uncovered SELLs with subsequent BUYs
2. Same-Day Rule (for remaining regular BUY/SELL)
3. 30-Day Rule (for remaining regular BUY/SELL)
4. Section 104 Pool (for remaining regular BUY/SELL)

Test cases:
- Basic short sell: SELL 100 when no prior BUYs, then BUY 100 → matched as short sell
- Partial short: BUY 50, SELL 100 → 50 normal, 50 short sell
- Gain calculation: sell high at £10, buy to cover at £8 → £2 profit per share
- Loss calculation: sell low at £8, buy to cover at £10 → £2 loss per share
- Multiple short sells covered by single BUY
- Single short sell covered by multiple BUYs
- Partial covering (SELL 100 short, only BUY 60 to cover → 40 uncovered)
- Different symbols handled independently
- FIFO matching verification (oldest short matched first)
- Mixed scenario: some short sells, some regular trades on same symbol