### PR TITLE
fix: make "Start Fresh" delete entire database to handle schema migrations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,7 @@ import { HelpPanel } from './components/HelpPanel'
 import { SessionResumeDialog } from './components/SessionResumeDialog'
 import { useTransactionStore } from './stores/transactionStore'
 import { useSettingsStore, useInitializeSettings } from './stores/settingsStore'
-import { db } from './lib/db'
+import { db, clearAllData } from './lib/db'
 import { processTransactionsFromDB } from './lib/transactionProcessor'
 
 function App() {
@@ -86,19 +86,8 @@ function App() {
   }
 
   const handleStartFresh = async () => {
-    // Delete entire IndexedDB database (handles schema migration issues)
-    await db.delete()
-
-    // Clear Zustand store
-    setTransactions([])
-
-    // Clear localStorage (Zustand persist)
-    localStorage.removeItem('cgt-settings')
-
     setShowSessionDialog(false)
-
-    // Reload page to ensure clean state
-    window.location.reload()
+    await clearAllData()
   }
 
   // Render About page

--- a/src/components/ClearDataButton.tsx
+++ b/src/components/ClearDataButton.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
-import { db } from '../lib/db'
-import { useTransactionStore } from '../stores/transactionStore'
+import { clearAllData } from '../lib/db'
 
 interface ClearDataButtonProps {
   variant?: 'default' | 'compact'
@@ -9,24 +8,11 @@ interface ClearDataButtonProps {
 export function ClearDataButton({ variant = 'default' }: ClearDataButtonProps) {
   const [showConfirm, setShowConfirm] = useState(false)
   const [isClearing, setIsClearing] = useState(false)
-  const setTransactions = useTransactionStore((state) => state.setTransactions)
 
   const handleClear = async () => {
     setIsClearing(true)
     try {
-      // Delete entire IndexedDB database (handles schema migration issues)
-      await db.delete()
-
-      // Clear Zustand store
-      setTransactions([])
-
-      // Clear localStorage (Zustand persist)
-      localStorage.removeItem('cgt-settings')
-
-      setShowConfirm(false)
-
-      // Reload page to ensure clean state
-      window.location.reload()
+      await clearAllData()
     } catch (err) {
       console.error('Failed to clear data:', err)
       setIsClearing(false)

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -71,3 +71,18 @@ export class CGTDatabase extends Dexie {
 }
 
 export const db = new CGTDatabase()
+
+/**
+ * Clears all application data (database + localStorage) and reloads the page.
+ * Use this for "Start Fresh" or "Clear All Data" functionality.
+ */
+export async function clearAllData(): Promise<void> {
+  // Delete entire IndexedDB database (handles schema migration issues)
+  await db.delete()
+
+  // Clear localStorage (Zustand persist)
+  localStorage.removeItem('cgt-settings')
+
+  // Reload page to ensure clean state
+  window.location.reload()
+}


### PR DESCRIPTION
The "Start Fresh" button in SessionResumeDialog was only clearing individual
tables (transactions, fx_rates, imported_files) while the "Clear All Data"
button properly deleted the entire database. This caused issues for users
upgrading from pre-v3 databases where fx_rates had an incompatible composite
key structure.

Now both cleanup functions use db.delete() to ensure proper schema migration
handling, clear localStorage settings, and reload the page for clean state.

Fixes #7