### PR TITLE
refactor: simplify code with config-driven patterns

### DIFF
--- a/src/lib/parsers/parserRegistry.ts
+++ b/src/lib/parsers/parserRegistry.ts
@@ -1,0 +1,47 @@
+/**
+ * Parser Registry
+ *
+ * Maps broker types to their respective parser functions.
+ * This eliminates the need for switch statements when selecting parsers.
+ */
+
+import { BrokerType, RawCSVRow } from '../../types/broker'
+import { GenericTransaction } from '../../types/transaction'
+import { normalizeSchwabTransactions } from './schwab'
+import { normalizeSchwabEquityAwardsTransactions } from './schwabEquityAwards'
+import { normalizeInteractiveBrokersTransactions } from './interactiveBrokers'
+import { normalizeGenericTransactions } from './generic'
+import { normalizeTrading212Transactions } from './trading212'
+import { normalizeFreetradeTransactions } from './freetrade'
+import { normalizeEquatePlusTransactions } from './equatePlus'
+import { normalizeRevolutTransactions } from './revolut'
+import { normalizeCoinbaseTransactions } from './coinbase'
+
+/**
+ * Parser function signature
+ */
+export type ParserFunction = (rows: RawCSVRow[], fileId: string) => GenericTransaction[]
+
+/**
+ * Registry mapping broker types to parser functions
+ */
+export const PARSER_REGISTRY: Record<BrokerType, ParserFunction | null> = {
+  [BrokerType.SCHWAB]: normalizeSchwabTransactions,
+  [BrokerType.SCHWAB_EQUITY_AWARDS]: normalizeSchwabEquityAwardsTransactions,
+  [BrokerType.INTERACTIVE_BROKERS]: normalizeInteractiveBrokersTransactions,
+  [BrokerType.FREETRADE]: normalizeFreetradeTransactions,
+  [BrokerType.EQUATE_PLUS]: normalizeEquatePlusTransactions,
+  [BrokerType.REVOLUT]: normalizeRevolutTransactions,
+  [BrokerType.COINBASE]: normalizeCoinbaseTransactions,
+  [BrokerType.GENERIC]: normalizeGenericTransactions,
+  [BrokerType.TRADING212]: normalizeTrading212Transactions,
+  [BrokerType.UNKNOWN]: null,
+}
+
+/**
+ * Get parser function for a broker type
+ * Returns null if broker is unknown or unsupported
+ */
+export function getParser(broker: BrokerType): ParserFunction | null {
+  return PARSER_REGISTRY[broker] ?? null
+}

--- a/src/lib/parsers/parsingUtils.ts
+++ b/src/lib/parsers/parsingUtils.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared parsing utilities for CSV parsers
+ *
+ * These utilities handle common parsing patterns across all broker parsers:
+ * - Date parsing from various formats to ISO YYYY-MM-DD
+ * - Number/currency parsing with symbol and comma handling
+ * - Currency code extraction from formatted amounts
+ */
+
+/**
+ * Parse a numeric value, handling empty strings, currency symbols, and commas
+ * Returns undefined for empty/invalid values
+ */
+export function parseNumber(value: string | undefined | null): number | undefined {
+  if (!value || value.trim() === '') return undefined
+
+  // Remove currency symbols ($, £, €) and commas
+  const cleaned = value.replace(/[$£€,]/g, '').trim()
+  const parsed = parseFloat(cleaned)
+
+  return isNaN(parsed) ? undefined : parsed
+}
+
+/**
+ * Parse a currency value, handling format like "$1,234.56" or "-$1,234.56"
+ * Returns null for empty/invalid values (matches GenericTransaction field types)
+ */
+export function parseCurrency(value: string | undefined | null): number | null {
+  const result = parseNumber(value)
+  return result === undefined ? null : result
+}
+
+/**
+ * Extract date part from ISO 8601 timestamp
+ * Handles formats like "2024-01-15T10:00:00.000Z" -> "2024-01-15"
+ */
+export function parseISODate(dateStr: string | undefined | null): string | null {
+  if (!dateStr) return null
+
+  const match = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (!match) return null
+
+  const [, year, month, day] = match
+  return `${year}-${month}-${day}`
+}
+
+/**
+ * Parse US date format (MM/DD/YYYY) to ISO (YYYY-MM-DD)
+ */
+export function parseUSDate(dateStr: string | undefined | null): string | null {
+  if (!dateStr) return null
+
+  const match = dateStr.trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/)
+  if (!match) return null
+
+  const [, month, day, year] = match
+  return `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`
+}
+
+/**
+ * Extract currency code from amount string with currency symbol
+ * Falls back to provided default if no symbol detected
+ */
+export function extractCurrencyFromAmount(amount: string | undefined | null, defaultCurrency = 'USD'): string {
+  if (!amount) return defaultCurrency
+
+  if (amount.includes('$')) return 'USD'
+  if (amount.includes('£')) return 'GBP'
+  if (amount.includes('€')) return 'EUR'
+
+  return defaultCurrency
+}
+
+/**
+ * Calculate total from price and quantity if amount is not available
+ */
+export function calculateTotal(
+  amount: number | null,
+  quantity: number | null,
+  price: number | null
+): number | null {
+  if (amount !== null) return Math.abs(amount)
+  if (quantity !== null && price !== null) return Math.abs(quantity * price)
+  return null
+}

--- a/src/lib/parsers/revolut.ts
+++ b/src/lib/parsers/revolut.ts
@@ -17,37 +17,37 @@ import type { RawCSVRow } from '../../types/broker'
  * - FX Rate: Exchange rate to GBP
  */
 
+type TransactionTypeString = 'BUY' | 'SELL' | 'DIVIDEND' | 'FEE' | 'INTEREST' | 'TRANSFER' | 'TAX' | 'STOCK_SPLIT'
+
+/**
+ * Keyword-based mappings for Revolut types (checked in order)
+ * Order matters: more specific patterns should come first
+ */
+const REVOLUT_TYPE_MAP: Array<{ keyword: string; type: TransactionTypeString }> = [
+  { keyword: 'buy', type: 'BUY' },
+  { keyword: 'sell', type: 'SELL' },
+  { keyword: 'dividend', type: 'DIVIDEND' },
+  { keyword: 'cash top-up', type: 'TRANSFER' },
+  { keyword: 'cash withdrawal', type: 'TRANSFER' },
+  { keyword: 'transfer from revolut', type: 'TRANSFER' },
+  { keyword: 'custody fee', type: 'FEE' },
+  { keyword: 'fee', type: 'FEE' },
+  { keyword: 'stock split', type: 'STOCK_SPLIT' },
+  { keyword: 'tax', type: 'TAX' },
+]
+
 /**
  * Map Revolut type to transaction type
  */
-function mapTypeToTransactionType(type: string): 'BUY' | 'SELL' | 'DIVIDEND' | 'FEE' | 'INTEREST' | 'TRANSFER' | 'TAX' | 'STOCK_SPLIT' {
+function mapTypeToTransactionType(type: string): TransactionTypeString {
   const typeLower = type.toLowerCase()
 
-  // Buy actions: BUY - MARKET, BUY - LIMIT
-  if (typeLower.includes('buy')) return 'BUY'
+  for (const { keyword, type: txType } of REVOLUT_TYPE_MAP) {
+    if (typeLower.includes(keyword)) {
+      return txType
+    }
+  }
 
-  // Sell actions: SELL - MARKET, SELL - LIMIT
-  if (typeLower.includes('sell')) return 'SELL'
-
-  // Dividend actions
-  if (typeLower.includes('dividend')) return 'DIVIDEND'
-
-  // Cash movements
-  if (typeLower.includes('cash top-up') || typeLower.includes('cash withdrawal')) return 'TRANSFER'
-
-  // Fees
-  if (typeLower.includes('custody fee') || typeLower.includes('fee')) return 'FEE'
-
-  // Transfers between Revolut entities
-  if (typeLower.includes('transfer from revolut')) return 'TRANSFER'
-
-  // Stock splits
-  if (typeLower.includes('stock split')) return 'STOCK_SPLIT'
-
-  // Tax-related
-  if (typeLower.includes('tax')) return 'TAX'
-
-  // Unknown types - default to FEE
   console.warn(`Unknown Revolut type: "${type}", treating as FEE`)
   return 'FEE'
 }

--- a/src/lib/parsers/schwab.ts
+++ b/src/lib/parsers/schwab.ts
@@ -1,5 +1,6 @@
 import { GenericTransaction, TransactionType } from '../../types/transaction'
 import { RawCSVRow } from '../../types/broker'
+import { calculateTotal } from './parsingUtils'
 
 /**
  * Parsed options symbol data
@@ -72,7 +73,7 @@ function normalizeSchwabRow(row: RawCSVRow, fileId: string, rowIndex: number): G
   const amount = parseSchwabCurrency(row['Amount']) || null
 
   // Calculate total (for buys, amount is negative, for sells positive)
-  const total = amount !== null ? Math.abs(amount) : (quantity && price ? Math.abs(quantity) * price : null)
+  const total = calculateTotal(amount, quantity, price)
 
   // Check if this is Stock Plan Activity
   const isStockPlanActivity = action?.toLowerCase() === 'stock plan activity'


### PR DESCRIPTION
- Add shared parsing utilities (parsingUtils.ts) for dates, numbers, currency
- Replace 9 broker detection functions with config-driven BROKER_CONFIGS array
- Create parser registry to replace 9-case switch statement in CSVImporter
- Convert transaction type mappings to use map-based approach (trading212, revolut)
- Fix nested ternary in schwab.ts using calculateTotal helper

All 349 tests pass. Functionality preserved.