### PR TITLE
Rewrite Interactive Brokers parser for Transaction History format

### DIFF
--- a/public/examples/interactive-brokers-example.csv
+++ b/public/examples/interactive-brokers-example.csv
@@ -1,13 +1,24 @@
-Trades,Header,DataDiscriminator,Asset Category,Currency,Symbol,Date/Time,Exchange,Quantity,T. Price,Proceeds,Comm/Fee,Basis,Realized P/L,Code
-Trades,Data,Order,Stocks,USD,AAPL,2024-01-15 10:30:42,NASDAQ,100,170.50,-17050.00,-1.00,,,
-Trades,Data,Trade,Stocks,USD,AAPL,2024-01-15 10:30:42,NASDAQ,100,170.50,-17050.00,-1.00,,,
-Trades,Data,Order,Stocks,USD,MSFT,2024-02-20 14:22:15,NASDAQ,50,400.00,-20000.00,-1.50,,,
-Trades,Data,Trade,Stocks,USD,MSFT,2024-02-20 14:22:15,NASDAQ,50,400.00,-20000.00,-1.50,,,
-Trades,Data,Order,Stocks,USD,NVDA,2024-03-10 09:15:30,NASDAQ,-25,850.00,21250.00,-2.00,,15000.00,
-Trades,Data,Trade,Stocks,USD,NVDA,2024-03-10 09:15:30,NASDAQ,-25,850.00,21250.00,-2.00,,15000.00,
-Trades,Data,ClosedLot,Stocks,USD,NVDA,2024-01-05 11:00:00,NASDAQ,25,250.00,-6250.00,,6250.00,,
-Trades,Data,SubTotal,Stocks,USD,NVDA,,,,-25,,21250.00,,,15000.00
-Trades,Data,Order,Stocks,SEK,HMBs,2024-04-15 08:45:20,STOCKHOLM,257,176.85,-45450.45,-12.50,,,
-Trades,Data,Trade,Stocks,SEK,HMBs,2024-04-15 08:45:20,STOCKHOLM,257,176.85,-45450.45,-12.50,,,
-Trades,Data,Order,Stocks,GBP,TSCO,2024-05-10 11:20:30,LSE,100,3.50,-350.00,-0.50,,,
-Trades,Data,Trade,Stocks,GBP,TSCO,2024-05-10 11:20:30,LSE,100,3.50,-350.00,-0.50,,,
+Statement,Header,Field Name,Field Value
+Statement,Data,Title,Transaction History
+Statement,Data,Period,"April 1, 2020 - June 2, 2025"
+Statement,Data,WhenGenerated,"2026-01-09, 10:01:42 EST"
+Summary,Header,Field Name,Field Value
+Summary,Data,Base Currency,GBP
+Summary,Data,Starting Cash,101.0
+Summary,Data,Change,1070.46
+Summary,Data,Ending Cash,1171.46
+Transaction History,Header,Date,Account,Description,Transaction Type,Symbol,Quantity,Price,Gross Amount ,Commission,Net Amount
+Transaction History,Data,2025-09-07,U1234567,Bond Coupon Payment (UKT 2 09/07/25 - United Kingdom Gilt UKT 2 09/07/25),Investment Interest Received,UKT 2 09/07/25,-,-,1100.00,-,1100.00
+Transaction History,Data,2025-08-15,U1234567,VANG S&P500 USDD,Sell,VUSD,-50.0,100.00,4500.00,-2.50,4497.50
+Transaction History,Data,2025-06-02,U1234567,FX Translations P&L,Adjustment,-,-,-,-593.38,-,-593.38
+Transaction History,Data,2025-04-02,U1234567,VUSD(IE00B3XXRP09) Cash Dividend USD 0.32063 per Share (Mixed Income),Dividend,VUSD,-,-,24.47,-,24.47
+Transaction History,Data,2025-03-25,U1234567,Purchase Accrued Interest UKT 0 5/8 06/07/25,Investment Interest Paid,UKT 0 5/8 06/07/25,-,-,-1.87,-,-1.87
+Transaction History,Data,2025-03-25,U1234567,UKT 0 5/8 06/07/25,Buy,UKT 0 5/8 06/07/25,1000.0,99.312,-993.12,-1.0,-994.12
+Transaction History,Data,2025-03-22,U1234567,Electronic Fund Transfer,Deposit,-,-,-,1000.0,-,1000.0
+Transaction History,Data,2024-10-03,U1234567,USD Credit Interest for Sep-2024,Credit Interest,-,-,-,0.91,-,0.91
+Transaction History,Data,2024-09-27,U1234567,VANG S&P500 USDD,Buy,VUSD,100.0,108.75,-8132.00,-4.49,-8136.49
+Transaction History,Data,2024-09-10,U1234567,JMIA(48138M105) ADR Fee USD 0.03 per Share,Other Fee,JMIA,-,-,-2.25,-,-2.25
+Transaction History,Data,2024-01-15,U1234567,Disbursement Initiated by John Smith,Withdrawal,-,-,-,-10000.0,-,-10000.0
+Transaction History,Data,2022-02-03,U1234567,USD Debit Interest for Jan-2022,Debit Interest,-,-,-,-14.63,-,-14.63
+Transaction History,Data,2022-01-21,U1234567,"Net Amount in Base from Forex Trade: -20,000 GBP.USD",Forex Trade Component,GBP.USD,-20000.0,1.35551,0.43,-1.47,0.43
+Transaction History,Data,2021-10-04,U1234567,VAT Account:Global Snapshot PnP,Sales Tax,-,-,-,-0.004,-,-0.004

--- a/src/lib/csvParser.ts
+++ b/src/lib/csvParser.ts
@@ -24,6 +24,113 @@ export async function parseCSV(file: File): Promise<RawCSVRow[]> {
 }
 
 /**
+ * Check if a file is an Interactive Brokers CSV
+ * IB CSVs have a distinctive multi-section format with:
+ * - "Statement" section at the start
+ * - "Transaction History" section with the actual trades
+ */
+export async function isInteractiveBrokersCSV(file: File): Promise<boolean> {
+  return new Promise((resolve) => {
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const text = e.target?.result as string
+      if (!text) {
+        resolve(false)
+        return
+      }
+      // Check for IB-specific patterns
+      const hasStatement = text.includes('Statement,Header,') || text.includes('Statement,Data,')
+      const hasTransactionHistory = text.includes('Transaction History,Header,') || text.includes('Transaction History,Data,')
+
+      resolve(hasStatement && hasTransactionHistory)
+    }
+    reader.onerror = () => resolve(false)
+    reader.readAsText(file.slice(0, 2000)) // Read first 2KB to check the structure
+  })
+}
+
+/**
+ * Preprocess Interactive Brokers CSV to handle its multi-section format
+ *
+ * IB CSVs have multiple sections with different column counts:
+ * - Statement: 4 columns (Statement,Header/Data,Field Name,Field Value)
+ * - Summary: 4 columns (Summary,Header/Data,Field Name,Field Value)
+ * - Transaction History: 11+ columns
+ *
+ * We need to extract each section's header and apply it to that section's data rows
+ */
+export async function preprocessInteractiveBrokersCSV(file: File): Promise<File> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const text = e.target?.result as string
+      if (!text) {
+        reject(new Error('Failed to read file'))
+        return
+      }
+
+      const lines = text.split('\n')
+      let headerRow: string | null = null
+      const summaryRows: string[] = []
+      const transactionRows: string[] = []
+
+      for (const line of lines) {
+        if (!line.trim()) continue
+
+        // Parse the line to extract section name and row type
+        // Use a simple regex since we just need the first two columns
+        const match = line.match(/^([^,]+),([^,]+),(.*)$/)
+        if (!match) {
+          continue
+        }
+
+        const sectionName = match[1]
+        const rowType = match[2]
+        const restOfLine = match[3]
+
+        if (rowType === 'Header') {
+          // Store the header for Transaction History section
+          if (sectionName === 'Transaction History') {
+            // Create header row with Section and RowType columns prepended
+            headerRow = `Section,RowType,${restOfLine}`
+          }
+        } else if (rowType === 'Data') {
+          // Collect data rows for Transaction History section
+          if (sectionName === 'Transaction History') {
+            transactionRows.push(`${sectionName},${rowType},${restOfLine}`)
+          } else if (sectionName === 'Summary') {
+            // Also include Summary section for base currency extraction
+            // Pad with empty columns to match Transaction History column count
+            summaryRows.push(`${sectionName},${rowType},${restOfLine},,,,,,,,`)
+          }
+        }
+      }
+
+      if (!headerRow) {
+        reject(new Error('Could not find Transaction History header in Interactive Brokers CSV'))
+        return
+      }
+
+      // Build the final CSV with header FIRST, then Summary rows, then Transaction History rows
+      const processedRows = [headerRow, ...summaryRows, ...transactionRows]
+
+      if (processedRows.length <= 1) {
+        reject(new Error('Could not find Transaction History data in Interactive Brokers CSV'))
+        return
+      }
+
+      const processedCsv = processedRows.join('\n')
+      const processedFile = new File([processedCsv], file.name, { type: file.type })
+      resolve(processedFile)
+    }
+    reader.onerror = () => {
+      reject(new Error('Failed to read file'))
+    }
+    reader.readAsText(file)
+  })
+}
+
+/**
  * Check if a file is a Coinbase CSV by reading the first few lines
  * Coinbase CSVs have a distinctive structure:
  * - Optional blank line(s) at the start

--- a/src/lib/parsers/interactiveBrokers.ts
+++ b/src/lib/parsers/interactiveBrokers.ts
@@ -2,14 +2,25 @@ import { GenericTransaction, TransactionType } from '../../types/transaction'
 import { RawCSVRow } from '../../types/broker'
 
 /**
+ * Transaction types from IB that represent actual trades (capital gains relevant)
+ */
+const TRADE_TRANSACTION_TYPES = ['Buy', 'Sell', 'Assignment']
+
+/**
+ * Transaction types from IB for dividends and interest
+ */
+const DIVIDEND_TRANSACTION_TYPES = ['Dividend']
+const INTEREST_TRANSACTION_TYPES = ['Credit Interest', 'Debit Interest', 'Investment Interest Paid', 'Investment Interest Received']
+
+/**
  * Normalize Interactive Brokers CSV rows to GenericTransaction format
  *
- * IB CSV has a multi-section format:
- * - First column: Section name (e.g., "Trades", "Cash Transactions", "Corporate Actions")
+ * IB Transaction History CSV has a multi-section format:
+ * - First column: Section name (e.g., "Transaction History", "Statement", "Summary")
  * - Second column: Row type ("Header" or "Data")
  * - Variable columns per section
  *
- * We focus on the "Trades" section for buy/sell transactions
+ * We focus on the "Transaction History" section for buy/sell transactions
  *
  * @param rows Raw CSV rows
  * @param fileId Unique identifier for this file
@@ -18,18 +29,20 @@ export function normalizeInteractiveBrokersTransactions(rows: RawCSVRow[], fileI
   const transactions: GenericTransaction[] = []
   let rowIndex = 1
 
-  // PapaParse with header:true already consumed the header row to create column names
-  // So all rows we receive are data rows with keys like: "Trades", "Header", "DataDiscriminator", etc.
-  // The first CSV row (Trades,Header,DataDiscriminator,...) became the column names
-  // All subsequent rows are data rows where row["Trades"] = "Trades", row["Header"] = "Data", etc.
+  // Extract base currency from Summary section if available
+  const baseCurrency = extractBaseCurrency(rows)
+
+  // After preprocessing, the CSV has proper column headers:
+  // Section, RowType, Date, Account, Description, Transaction Type, Symbol, Quantity, Price, Gross Amount, Commission, Net Amount
+  // Summary rows are included for base currency extraction, with extra columns padded
 
   for (const row of rows) {
-    const sectionName = row['Trades']
-    const rowType = row['Header']
+    const sectionName = row['Section']
+    const rowType = row['RowType']
 
-    // Process only "Trades,Data" rows (skip other sections)
-    if (sectionName === 'Trades' && rowType === 'Data') {
-      const normalized = normalizeIBTradeRow(row, fileId, rowIndex)
+    // Process only "Transaction History,Data" rows
+    if (sectionName === 'Transaction History' && rowType === 'Data') {
+      const normalized = normalizeIBTransactionHistoryRow(row, fileId, rowIndex, baseCurrency)
       if (normalized) {
         transactions.push(normalized)
         rowIndex++
@@ -41,65 +54,171 @@ export function normalizeInteractiveBrokersTransactions(rows: RawCSVRow[], fileI
 }
 
 /**
- * Normalize a single IB trade row
+ * Extract base currency from Summary section
+ * Works with both preprocessed and raw formats
  */
-function normalizeIBTradeRow(
+function extractBaseCurrency(rows: RawCSVRow[]): string {
+  for (const row of rows) {
+    // Preprocessed format: Section, RowType columns
+    const sectionName = row['Section']
+    const rowType = row['RowType']
+
+    // In preprocessed format, Summary rows have Date column containing "Base Currency"
+    // because the columns are: Section, RowType, Date (which maps to Field Name for Summary rows)
+    if (sectionName === 'Summary' && rowType === 'Data') {
+      const fieldName = row['Date'] // Field Name is in the Date column position
+      const fieldValue = row['Account'] // Field Value is in the Account column position
+      if (fieldName === 'Base Currency') {
+        return fieldValue || 'USD'
+      }
+    }
+  }
+  return 'USD'
+}
+
+/**
+ * Normalize a single IB Transaction History row
+ */
+function normalizeIBTransactionHistoryRow(
   row: RawCSVRow,
   fileId: string,
-  rowIndex: number
+  rowIndex: number,
+  baseCurrency: string
 ): GenericTransaction | null {
-  // With PapaParse header:true, row is already a key-value object
-  // where keys are column names from the first row
-  // row = { "Trades": "Trades", "Header": "Data", "DataDiscriminator": "Trade", ... }
-
-  // Extract DataDiscriminator to filter row types
-  // We only want "Trade" rows (actual executions), not "Order", "ClosedLot", or "SubTotal"
-  const dataDiscriminator = row['DataDiscriminator']
-  if (dataDiscriminator !== 'Trade') {
+  const transactionType = row['Transaction Type']?.trim()
+  if (!transactionType) {
     return null
   }
 
-  // Extract key fields directly from row object
-  const symbol = row['Symbol']?.trim()
-  const currency = row['Currency']?.trim()
-  const assetCategory = row['Asset Category']?.trim()
-  const dateTime = parseIBDateTime(row['Date/Time'])
+  // Extract common fields
+  const dateStr = row['Date']?.trim()
+  const description = row['Description']?.trim()
 
-  if (!dateTime || !symbol) {
-    return null // Skip invalid rows
+  // Parse date (format: YYYY-MM-DD)
+  const date = parseIBDate(dateStr)
+  if (!date) {
+    return null
+  }
+
+  // Handle trade transactions (Buy, Sell, Assignment)
+  if (TRADE_TRANSACTION_TYPES.includes(transactionType)) {
+    return normalizeTradeRow(row, fileId, rowIndex, baseCurrency, transactionType, date, description)
+  }
+
+  // Handle dividend transactions
+  if (DIVIDEND_TRANSACTION_TYPES.includes(transactionType)) {
+    return normalizeDividendRow(row, fileId, rowIndex, baseCurrency, date, description)
+  }
+
+  // Handle interest transactions
+  if (INTEREST_TRANSACTION_TYPES.includes(transactionType)) {
+    return normalizeInterestRow(row, fileId, rowIndex, baseCurrency, transactionType, date, description)
+  }
+
+  return null
+}
+
+/**
+ * Normalize a trade row (Buy, Sell, Assignment)
+ */
+function normalizeTradeRow(
+  row: RawCSVRow,
+  fileId: string,
+  rowIndex: number,
+  baseCurrency: string,
+  transactionType: string,
+  date: string,
+  description: string | undefined
+): GenericTransaction | null {
+  const symbol = row['Symbol']?.trim()
+
+  if (!symbol || symbol === '-') {
+    return null // Skip invalid rows or rows with no symbol
+  }
+
+  // Skip bonds (symbols like "UKT 0 5/8 06/07/25" contain spaces and fractions)
+  if (isBondSymbol(symbol)) {
+    return null
   }
 
   // Parse numeric values
-  const quantity = parseFloat(row['Quantity']) || null
-  const tPrice = parseFloat(row['T. Price']) || null
-  const proceeds = parseFloat(row['Proceeds']) || null
-  const commFee = Math.abs(parseFloat(row['Comm/Fee']) || 0)
+  // Quantity can be negative for sells
+  const rawQuantity = parseFloat(row['Quantity']) || null
+  const commission = Math.abs(parseFloat(row['Commission']) || 0)
 
-  // Determine transaction type based on quantity sign
-  // In IB CSV: positive quantity = BUY, negative quantity = SELL
-  const type = quantity && quantity < 0 ? TransactionType.SELL : TransactionType.BUY
+  // IMPORTANT: In IB exports, Price is in the original transaction currency,
+  // but Gross Amount and Net Amount are already converted to the base currency (e.g., GBP).
+  // We use Gross Amount directly as the total, and derive the price from it.
+  const grossAmount = parseFloat(row['Gross Amount '] || row['Gross Amount']) || null
 
-  // Calculate total from proceeds (make positive)
-  const total = proceeds !== null ? Math.abs(proceeds) : null
+  // Calculate total from gross amount (make positive)
+  const total = grossAmount !== null ? Math.abs(grossAmount) : null
 
-  // For now, we only support stocks. Options and other asset types can be added later
-  const isStock = assetCategory === 'Stocks'
-  if (!isStock) {
-    return null // Skip non-stock transactions for now
+  // Derive price in base currency from gross amount / quantity
+  let price: number | null = null
+  if (total !== null && rawQuantity !== null && Math.abs(rawQuantity) > 0) {
+    price = total / Math.abs(rawQuantity)
+  }
+
+  // Determine transaction type
+  let type: (typeof TransactionType)[keyof typeof TransactionType]
+  if (transactionType === 'Sell') {
+    type = TransactionType.SELL
+  } else {
+    type = TransactionType.BUY
   }
 
   return {
     id: `${fileId}-${rowIndex}`,
     source: 'Interactive Brokers',
     symbol: symbol,
-    name: null, // IB doesn't provide a description in the trades section
-    date: dateTime,
+    name: description || null,
+    date,
     type,
-    quantity: quantity !== null ? Math.abs(quantity) : null, // Store as positive
-    price: tPrice,
-    currency: currency || 'USD',
+    quantity: rawQuantity !== null ? Math.abs(rawQuantity) : null,
+    price,
+    currency: baseCurrency,
     total,
-    fee: commFee || null,
+    fee: commission || null,
+    ratio: null,
+    notes: transactionType === 'Assignment' ? 'Options Assignment' : null,
+    incomplete: false,
+    ignored: false,
+  }
+}
+
+/**
+ * Normalize a dividend row
+ */
+function normalizeDividendRow(
+  row: RawCSVRow,
+  fileId: string,
+  rowIndex: number,
+  baseCurrency: string,
+  date: string,
+  description: string | undefined
+): GenericTransaction | null {
+  const symbol = row['Symbol']?.trim()
+
+  if (!symbol || symbol === '-') {
+    return null
+  }
+
+  const grossAmount = parseFloat(row['Gross Amount '] || row['Gross Amount']) || null
+  const total = grossAmount !== null ? Math.abs(grossAmount) : null
+
+  return {
+    id: `${fileId}-${rowIndex}`,
+    source: 'Interactive Brokers',
+    symbol: symbol,
+    name: description || null,
+    date,
+    type: TransactionType.DIVIDEND,
+    quantity: null,
+    price: null,
+    currency: baseCurrency,
+    total,
+    fee: null,
     ratio: null,
     notes: null,
     incomplete: false,
@@ -108,18 +227,86 @@ function normalizeIBTradeRow(
 }
 
 /**
- * Parse IB date/time format: "YYYY-MM-DD HH:MM:SS" or "YYYY-MM-DD;HH:MM:SS"
+ * Normalize an interest row (Credit Interest, Debit Interest, Investment Interest Paid)
+ */
+function normalizeInterestRow(
+  row: RawCSVRow,
+  fileId: string,
+  rowIndex: number,
+  baseCurrency: string,
+  transactionType: string,
+  date: string,
+  description: string | undefined
+): GenericTransaction | null {
+  // Interest transactions typically don't have a symbol
+  // Use "CASH" as a placeholder symbol for interest transactions
+  const symbol = 'CASH'
+
+  const grossAmount = parseFloat(row['Gross Amount '] || row['Gross Amount']) || null
+
+  // Interest types:
+  // - Credit Interest: positive (income received)
+  // - Debit Interest: negative (paid to broker for margin)
+  // - Investment Interest Paid: negative (paid to seller for bonds)
+  // We preserve the value as-is since negative values indicate money paid out
+  const total = grossAmount
+
+  // Determine if it's credit or debit interest for notes
+  const isDebit = transactionType === 'Debit Interest' || transactionType === 'Investment Interest Paid'
+  const notes = isDebit ? 'Debit Interest' : 'Credit Interest'
+
+  return {
+    id: `${fileId}-${rowIndex}`,
+    source: 'Interactive Brokers',
+    symbol: symbol,
+    name: description || null,
+    date,
+    type: TransactionType.INTEREST,
+    quantity: null,
+    price: null,
+    currency: baseCurrency,
+    total,
+    fee: null,
+    ratio: null,
+    notes,
+    incomplete: false,
+    ignored: false,
+  }
+}
+
+/**
+ * Parse IB date format: "YYYY-MM-DD"
  * Returns ISO date string (YYYY-MM-DD) or null
  */
-function parseIBDateTime(dateTimeStr: string): string | null {
-  if (!dateTimeStr) return null
-
-  // Handle both semicolon and space separators
-  const datePart = dateTimeStr.split(/[; ]/)[0].trim()
+function parseIBDate(dateStr: string): string | null {
+  if (!dateStr) return null
 
   // Validate ISO date format
-  const match = datePart.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  const match = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})$/)
   if (!match) return null
 
-  return datePart
+  return dateStr
+}
+
+/**
+ * Check if a symbol represents a bond
+ * Bonds typically have spaces and contain fractions like "0 5/8" or maturity dates
+ */
+function isBondSymbol(symbol: string): boolean {
+  // Bond symbols typically contain fractions (e.g., "0 5/8") or multiple spaces
+  // Examples: "UKT 0 5/8 06/07/25"
+  // Stock/options don't have fractions in their symbols
+  if (symbol.includes('/') && symbol.includes(' ')) {
+    return true
+  }
+
+  // Check for government bond patterns (e.g., "UKT 0" - government code followed by coupon rate)
+  // These start with 2-3 letter government code, space, then a digit representing coupon
+  // Options are different: "SQ    220916C00210000" - ticker, spaces, date+strike
+  // Key difference: bonds have "UKT 0" pattern (code + single digit coupon), options have 6+ digit date codes
+  if (/^[A-Z]{2,3}\s+\d\s/.test(symbol)) {
+    return true
+  }
+
+  return false
 }


### PR DESCRIPTION
Rewrote the Interactive Brokers parser to support the new Transaction History export format, which replaces the previous Trades format.

Key changes:
- Update broker detector for Transaction History/Statement/Summary sections
- Add CSV preprocessing to handle multi-section format with variable columns
- Support Buy, Sell, Dividend, and Interest transaction types
- Use Gross Amount (already in base currency) for pricing and totals
- Extract base currency from Summary section
- Simplify export instructions in UI

Tests: 342 tests passing