### PR TITLE
feat: add CGT rate change split for 30 October 2024

### DIFF
--- a/src/components/PDFExport.tsx
+++ b/src/components/PDFExport.tsx
@@ -251,6 +251,66 @@ function createCGTReportDocument(Document: any, Page: any, Text: any, View: any,
             </>
           )}
 
+          {/* CGT Rate Change Notice (for 2024/25) */}
+          {taxYearSummary.hasRateChange && (
+            <>
+              <Text style={styles.subtitle}>CGT Rate Change — 30 October 2024</Text>
+              <View style={[styles.summaryBox, { backgroundColor: '#fffbeb', borderWidth: 1, borderColor: '#fde68a' }]}>
+                <Text style={{ fontSize: 8, color: '#92400e', marginBottom: 8 }}>
+                  From 30 October 2024, CGT rates increased from 10%/20% to 18%/24%. Report these periods separately on your Self Assessment.
+                </Text>
+
+                <Text style={{ fontSize: 9, fontFamily: 'Helvetica-Bold', color: '#92400e', marginBottom: 4 }}>
+                  Before 30 Oct 2024 (10%/20% rates)
+                </Text>
+                <View style={styles.summaryRow}>
+                  <Text style={styles.summaryLabel}>Gains:</Text>
+                  <Text style={[styles.summaryValue, { color: '#059669' }]}>
+                    {formatCurrency(taxYearSummary.gainsBeforeRateChange ?? 0)}
+                  </Text>
+                </View>
+                <View style={styles.summaryRow}>
+                  <Text style={styles.summaryLabel}>Losses:</Text>
+                  <Text style={[styles.summaryValue, { color: '#dc2626' }]}>
+                    ({formatCurrency(Math.abs(taxYearSummary.lossesBeforeRateChange ?? 0))})
+                  </Text>
+                </View>
+                <View style={[styles.summaryRow, { marginBottom: 12 }]}>
+                  <Text style={[styles.summaryLabel, { fontFamily: 'Helvetica-Bold' }]}>Net:</Text>
+                  <Text style={[styles.summaryValue, { color: (taxYearSummary.netGainOrLossBeforeRateChange ?? 0) >= 0 ? '#059669' : '#dc2626' }]}>
+                    {formatCurrency(taxYearSummary.netGainOrLossBeforeRateChange ?? 0)}
+                  </Text>
+                </View>
+
+                <Text style={{ fontSize: 9, fontFamily: 'Helvetica-Bold', color: '#92400e', marginBottom: 4 }}>
+                  From 30 Oct 2024 (18%/24% rates)
+                </Text>
+                <View style={styles.summaryRow}>
+                  <Text style={styles.summaryLabel}>Gains:</Text>
+                  <Text style={[styles.summaryValue, { color: '#059669' }]}>
+                    {formatCurrency(taxYearSummary.gainsAfterRateChange ?? 0)}
+                  </Text>
+                </View>
+                <View style={styles.summaryRow}>
+                  <Text style={styles.summaryLabel}>Losses:</Text>
+                  <Text style={[styles.summaryValue, { color: '#dc2626' }]}>
+                    ({formatCurrency(Math.abs(taxYearSummary.lossesAfterRateChange ?? 0))})
+                  </Text>
+                </View>
+                <View style={styles.summaryRow}>
+                  <Text style={[styles.summaryLabel, { fontFamily: 'Helvetica-Bold' }]}>Net:</Text>
+                  <Text style={[styles.summaryValue, { color: (taxYearSummary.netGainOrLossAfterRateChange ?? 0) >= 0 ? '#059669' : '#dc2626' }]}>
+                    {formatCurrency(taxYearSummary.netGainOrLossAfterRateChange ?? 0)}
+                  </Text>
+                </View>
+
+                <Text style={{ fontSize: 7, color: '#92400e', marginTop: 8 }}>
+                  Source: https://www.gov.uk/government/publications/changes-to-the-rates-of-capital-gains-tax
+                </Text>
+              </View>
+            </>
+          )}
+
           {/* Disposal Records */}
           {disposals.length > 0 && (
             <>

--- a/src/components/TaxYearSummary.tsx
+++ b/src/components/TaxYearSummary.tsx
@@ -273,6 +273,82 @@ export function TaxYearSummary() {
           </div>
         </div>
 
+        {/* CGT Rate Change Notice (for 2024/25) */}
+        {currentSummary.hasRateChange && (
+          <div className="bg-amber-50 border border-amber-200 rounded-lg p-4">
+            <div className="flex items-start">
+              <svg className="h-5 w-5 text-amber-500 mt-0.5 flex-shrink-0" viewBox="0 0 20 20" fill="currentColor">
+                <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
+              </svg>
+              <div className="ml-3 flex-1">
+                <h4 className="text-sm font-semibold text-amber-900 mb-2">
+                  CGT Rate Change — 30 October 2024
+                  <Tooltip content="View HMRC guidance on CGT rate changes">
+                    <a
+                      href="https://www.gov.uk/government/publications/changes-to-the-rates-of-capital-gains-tax"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="ml-1 text-amber-600 hover:text-amber-800 underline text-xs font-normal"
+                    >
+                      (HMRC guidance)
+                    </a>
+                  </Tooltip>
+                </h4>
+                <p className="text-xs text-amber-700 mb-3">
+                  From 30 October 2024, CGT rates increased from 10%/20% to 18%/24%. Report these periods separately on your Self Assessment.
+                </p>
+                <div className="space-y-2 text-sm">
+                  <div className="flex justify-between items-center py-1 border-b border-amber-200">
+                    <span className="text-amber-800 font-medium">Before 30 Oct 2024 (10%/20% rates)</span>
+                    <span></span>
+                  </div>
+                  <div className="flex justify-between items-center pl-3">
+                    <span className="text-amber-700">Gains</span>
+                    <span className="font-medium text-green-700">
+                      £{(currentSummary.gainsBeforeRateChange ?? 0).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center pl-3">
+                    <span className="text-amber-700">Losses</span>
+                    <span className="font-medium text-red-700">
+                      (£{Math.abs(currentSummary.lossesBeforeRateChange ?? 0).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })})
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center pl-3 pb-2">
+                    <span className="text-amber-800 font-medium">Net</span>
+                    <span className={`font-semibold ${(currentSummary.netGainOrLossBeforeRateChange ?? 0) >= 0 ? 'text-green-700' : 'text-red-700'}`}>
+                      £{(currentSummary.netGainOrLossBeforeRateChange ?? 0).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    </span>
+                  </div>
+
+                  <div className="flex justify-between items-center py-1 border-b border-amber-200 border-t pt-3">
+                    <span className="text-amber-800 font-medium">From 30 Oct 2024 (18%/24% rates)</span>
+                    <span></span>
+                  </div>
+                  <div className="flex justify-between items-center pl-3">
+                    <span className="text-amber-700">Gains</span>
+                    <span className="font-medium text-green-700">
+                      £{(currentSummary.gainsAfterRateChange ?? 0).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center pl-3">
+                    <span className="text-amber-700">Losses</span>
+                    <span className="font-medium text-red-700">
+                      (£{Math.abs(currentSummary.lossesAfterRateChange ?? 0).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })})
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center pl-3">
+                    <span className="text-amber-800 font-medium">Net</span>
+                    <span className={`font-semibold ${(currentSummary.netGainOrLossAfterRateChange ?? 0) >= 0 ? 'text-green-700' : 'text-red-700'}`}>
+                      £{(currentSummary.netGainOrLossAfterRateChange ?? 0).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
         {/* Tax Status Message */}
         {hasTaxableGain ? (
           <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">

--- a/src/types/cgt.ts
+++ b/src/types/cgt.ts
@@ -127,6 +127,30 @@ export interface TaxYearSummary {
   totalInterestGbp: number
   /** Number of disposals with incomplete/missing acquisition data */
   incompleteDisposals: number
+  /**
+   * CGT Rate Change Split (for 2024/25 tax year)
+   *
+   * From 30 October 2024, CGT rates changed:
+   * - Basic rate: 10% → 18%
+   * - Higher rate: 20% → 24%
+   *
+   * These fields split gains/losses for accurate Self Assessment reporting.
+   * @see https://www.gov.uk/government/publications/changes-to-the-rates-of-capital-gains-tax
+   */
+  /** Gains from disposals before 30 Oct 2024 (old rates: 10%/20%) */
+  gainsBeforeRateChange?: number
+  /** Losses from disposals before 30 Oct 2024 */
+  lossesBeforeRateChange?: number
+  /** Net gain/loss before rate change */
+  netGainOrLossBeforeRateChange?: number
+  /** Gains from disposals on/after 30 Oct 2024 (new rates: 18%/24%) */
+  gainsAfterRateChange?: number
+  /** Losses from disposals on/after 30 Oct 2024 */
+  lossesAfterRateChange?: number
+  /** Net gain/loss after rate change */
+  netGainOrLossAfterRateChange?: number
+  /** Whether this tax year has a mid-year rate change */
+  hasRateChange?: boolean
 }
 
 /**


### PR DESCRIPTION
From 30 October 2024, CGT rates changed from 10%/20% to 18%/24%. This feature splits gains/losses for tax year 2024/25 into two periods to support accurate Self Assessment reporting.

Key changes:
- Add rate change fields to TaxYearSummary type (gainsBeforeRateChange, gainsAfterRateChange, lossesBeforeRateChange, lossesAfterRateChange, netGainOrLossBeforeRateChange, netGainOrLossAfterRateChange, hasRateChange)
- Add calculateRateChangeSplit() function in CGT engine for 2024/25 tax year
- Add CGT Rate Change panel to TaxYearSummary UI with HMRC guidance link
- Add CGT Rate Change section to PDF export
- Add 8 new tests covering rate change scenarios

Reference: https://www.gov.uk/government/publications/changes-to-the-rates-of-capital-gains-tax