### PR TITLE
fix: use pull_request_target and base branch for forked PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,7 +1,7 @@
 name: Claude Code Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
     # Optional: Only run on specific file changes
     # paths:
@@ -29,6 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 1
 
       - name: Run Claude Code Review


### PR DESCRIPTION
Changes:
- Changed trigger from 'pull_request' to 'pull_request_target' to enable write permissions for forked PRs
- Modified checkout to use base branch ref instead of PR branch to prevent prompt injection attacks via malicious .claude/review-instructions.md

This fixes the "Actor does not have write permissions" error when reviewing PRs from forks while maintaining security by using trusted review instructions from the base repository.