### PR TITLE
fix: correct code-review plugin command syntax in workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,7 +41,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |
-            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            /code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
             IMPORTANT: Follow the project-specific code review instructions in .claude/review-instructions.md
 


### PR DESCRIPTION
The code-review plugin uses `/code-review` command, not `/code-review:code-review`.
The redundant command format was causing the GitHub Actions workflow to fail.