### PR TITLE
fix: add --comment flag to post code review on PR

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,7 +41,7 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: |
-            /code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            /code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 
             IMPORTANT: Follow the project-specific code review instructions in .claude/review-instructions.md
 


### PR DESCRIPTION
Without the --comment flag, the code-review plugin only outputs to the terminal. Adding this flag ensures reviews are posted as PR comments for visibility.