### PR TITLE
docs: add website link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **UK Capital Gains Tax made easy**
 
+**Try it now at [cgtvisualiser.co.uk](https://cgtvisualiser.co.uk)**
+
 A free, privacy-focused web application that helps UK taxpayers understand and calculate capital gains tax on share transactions. All calculations happen in your browser - your data never leaves your device.
 
 ## Features


### PR DESCRIPTION
Add prominent link to https://cgtvisualiser.co.uk at the top of README
for easy access to the live application.