### PR TITLE
refactor: simplify code review workflow to use direct prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Run Claude Code Review
         uses: anthropics/claude-code-action@v1
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           prompt: |
             Review this PR with the following focus areas specific to this Capital Gains Tax Visualiser project:


### PR DESCRIPTION
Remove plugin-based approach in favor of inline review instructions:
- Replace plugin_marketplaces/plugins with direct prompt
- Switch from oauth token to anthropic_api_key
- Add track_progress for visual progress tracking
- Include HMRC compliance, code quality, and privacy review criteria
- Add claude_args for inline comment tools