### PR TITLE
refactor: abstract PDF exporter from tax year feature specifics

### DIFF
--- a/src/components/PDFExport.tsx
+++ b/src/components/PDFExport.tsx
@@ -1,6 +1,6 @@
 import type { TaxYearSummary, DisposalRecord } from '../types/cgt'
 import type { EnrichedTransaction } from '../types/transaction'
-import type { CGTRateChange2024Data } from '../lib/cgt/taxYearFeatures'
+import { renderAllFeaturePDFSections } from '../lib/cgt/taxYearFeatures'
 
 /**
  * Lazy-load @react-pdf/renderer to avoid including it in the main bundle.
@@ -252,74 +252,13 @@ function createCGTReportDocument(Document: any, Page: any, Text: any, View: any,
             </>
           )}
 
-          {/* CGT Rate Change 2024/25 Feature */}
-          {taxYearSummary.features?.['cgt-rate-change-2024'] && (() => {
-            const rateChangeData = taxYearSummary.features['cgt-rate-change-2024'] as CGTRateChange2024Data
-            return (
-              <>
-                <Text style={styles.subtitle}>2024 CGT Rate Change — 30 October 2024</Text>
-                <View style={[styles.summaryBox, { backgroundColor: rateChangeData.requiresAdjustment ? '#fffbeb' : '#eff6ff', borderWidth: 1, borderColor: rateChangeData.requiresAdjustment ? '#fde68a' : '#bfdbfe' }]}>
-                  {rateChangeData.requiresAdjustment ? (
-                    <>
-                      <Text style={{ fontSize: 8, color: '#92400e', marginBottom: 8, fontStyle: 'italic' }}>
-                        Box 51 Adjustment Required: Use these figures in HMRC's CGT adjustment calculator.
-                      </Text>
-                      {/* Before 30 Oct */}
-                      {(rateChangeData.gainsBeforeRateChange > 0 || rateChangeData.lossesBeforeRateChange < 0) && (
-                        <>
-                          <Text style={{ fontSize: 9, fontFamily: 'Helvetica-Bold', color: '#92400e', marginBottom: 4 }}>
-                            Before 30 Oct 2024 ({rateChangeData.oldRates.basic}%/{rateChangeData.oldRates.higher}% rates)
-                          </Text>
-                          <View style={styles.summaryRow}>
-                            <Text style={styles.summaryLabel}>Gains:</Text>
-                            <Text style={[styles.summaryValue, { color: '#059669' }]}>{formatCurrency(rateChangeData.gainsBeforeRateChange)}</Text>
-                          </View>
-                          <View style={styles.summaryRow}>
-                            <Text style={styles.summaryLabel}>Losses:</Text>
-                            <Text style={[styles.summaryValue, { color: '#dc2626' }]}>({formatCurrency(Math.abs(rateChangeData.lossesBeforeRateChange))})</Text>
-                          </View>
-                          <View style={[styles.summaryRow, { marginBottom: 8 }]}>
-                            <Text style={styles.summaryLabel}>Net:</Text>
-                            <Text style={[styles.summaryValue, { color: rateChangeData.netGainOrLossBeforeRateChange >= 0 ? '#059669' : '#dc2626' }]}>
-                              {formatCurrency(rateChangeData.netGainOrLossBeforeRateChange)}
-                            </Text>
-                          </View>
-                        </>
-                      )}
-                      {/* From 30 Oct */}
-                      <Text style={{ fontSize: 9, fontFamily: 'Helvetica-Bold', color: '#92400e', marginBottom: 4, marginTop: rateChangeData.gainsBeforeRateChange > 0 ? 4 : 0, paddingTop: rateChangeData.gainsBeforeRateChange > 0 ? 4 : 0, borderTopWidth: rateChangeData.gainsBeforeRateChange > 0 ? 1 : 0, borderTopColor: '#fde68a' }}>
-                        From 30 Oct 2024 ({rateChangeData.newRates.basic}%/{rateChangeData.newRates.higher}% rates)
-                      </Text>
-                      <View style={styles.summaryRow}>
-                        <Text style={styles.summaryLabel}>Gains:</Text>
-                        <Text style={[styles.summaryValue, { color: '#059669' }]}>{formatCurrency(rateChangeData.gainsAfterRateChange)}</Text>
-                      </View>
-                      <View style={styles.summaryRow}>
-                        <Text style={styles.summaryLabel}>Losses:</Text>
-                        <Text style={[styles.summaryValue, { color: '#dc2626' }]}>({formatCurrency(Math.abs(rateChangeData.lossesAfterRateChange))})</Text>
-                      </View>
-                      <View style={styles.summaryRow}>
-                        <Text style={styles.summaryLabel}>Net:</Text>
-                        <Text style={[styles.summaryValue, { color: rateChangeData.netGainOrLossAfterRateChange >= 0 ? '#059669' : '#dc2626' }]}>
-                          {formatCurrency(rateChangeData.netGainOrLossAfterRateChange)}
-                        </Text>
-                      </View>
-                      <Text style={{ fontSize: 7, color: '#92400e', marginTop: 8 }}>
-                        Use HMRC's calculator: gov.uk/guidance/work-out-your-capital-gains-tax-adjustment-for-the-2024-to-2025-tax-year
-                      </Text>
-                    </>
-                  ) : (
-                    <Text style={{ fontSize: 8, color: '#1e40af' }}>
-                      {rateChangeData.totalNetGainOrLoss <= rateChangeData.annualExemptAmount
-                        ? `Net gain (${formatCurrency(rateChangeData.totalNetGainOrLoss)}) is below Annual Exempt Amount (${formatCurrency(rateChangeData.annualExemptAmount)}). No CGT adjustment needed.`
-                        : `All disposals were before 30 October 2024. No CGT adjustment needed.`
-                      }
-                    </Text>
-                  )}
-                </View>
-              </>
-            )
-          })()}
+          {/* Tax Year Features - dynamically rendered based on registry */}
+          {renderAllFeaturePDFSections(taxYearSummary.features, {
+            Text,
+            View,
+            styles,
+            formatCurrency,
+          })}
 
           {/* Disposal Records */}
           {disposals.length > 0 && (

--- a/src/lib/cgt/taxYearFeatures/index.ts
+++ b/src/lib/cgt/taxYearFeatures/index.ts
@@ -11,6 +11,8 @@ export type {
   TaxYearFeature,
   TaxYearFeatureData,
   TaxYearFeaturesMap,
+  PDFRenderContext,
+  FeaturePDFRenderer,
 } from './types'
 
 // Registry functions
@@ -30,3 +32,6 @@ export {
   CGT_RATES,
 } from './cgtRateChange2024'
 export type { CGTRateChange2024Data } from './cgtRateChange2024'
+
+// PDF rendering
+export { renderAllFeaturePDFSections } from './pdfRenderers'

--- a/src/lib/cgt/taxYearFeatures/pdfRenderers/cgtRateChange2024PDF.tsx
+++ b/src/lib/cgt/taxYearFeatures/pdfRenderers/cgtRateChange2024PDF.tsx
@@ -1,0 +1,162 @@
+/**
+ * PDF Renderer for CGT Rate Change 2024 Feature
+ *
+ * Renders the 2024/25 CGT rate change section in PDF exports.
+ * This module encapsulates all 2024-specific PDF rendering logic,
+ * keeping the main PDFExport component clean and extensible.
+ */
+
+import type { CGTRateChange2024Data } from '../cgtRateChange2024'
+import type { FeaturePDFRenderer, PDFRenderContext } from '../types'
+
+/**
+ * Render the CGT Rate Change 2024 section for PDF export.
+ *
+ * Shows different content based on whether Box 51 adjustment is required:
+ * - Required: Detailed breakdown of gains/losses before and after 30 Oct 2024
+ * - Not required: Brief explanation of why no adjustment is needed
+ */
+export const renderCGTRateChange2024PDF: FeaturePDFRenderer<CGTRateChange2024Data> = (
+  data,
+  context
+) => {
+  const { Text, View, styles } = context
+
+  return (
+    <>
+      <Text style={styles.subtitle}>2024 CGT Rate Change — 30 October 2024</Text>
+      <View
+        style={[
+          styles.summaryBox,
+          {
+            backgroundColor: data.requiresAdjustment ? '#fffbeb' : '#eff6ff',
+            borderWidth: 1,
+            borderColor: data.requiresAdjustment ? '#fde68a' : '#bfdbfe',
+          },
+        ]}
+      >
+        {data.requiresAdjustment ? (
+          <AdjustmentRequiredContent data={data} context={context} />
+        ) : (
+          <NoAdjustmentRequiredContent data={data} context={context} />
+        )}
+      </View>
+    </>
+  )
+}
+
+interface ContentProps {
+  data: CGTRateChange2024Data
+  context: PDFRenderContext
+}
+
+/**
+ * Content for when Box 51 adjustment is required
+ */
+function AdjustmentRequiredContent({ data, context }: ContentProps): React.ReactElement {
+  const { Text, View, styles, formatCurrency } = context
+
+  return (
+    <>
+      <Text style={{ fontSize: 8, color: '#92400e', marginBottom: 8, fontStyle: 'italic' }}>
+        Box 51 Adjustment Required: Use these figures in HMRC's CGT adjustment calculator.
+      </Text>
+
+      {/* Before 30 Oct section */}
+      {(data.gainsBeforeRateChange > 0 || data.lossesBeforeRateChange < 0) && (
+        <>
+          <Text
+            style={{
+              fontSize: 9,
+              fontFamily: 'Helvetica-Bold',
+              color: '#92400e',
+              marginBottom: 4,
+            }}
+          >
+            Before 30 Oct 2024 ({data.oldRates.basic}%/{data.oldRates.higher}% rates)
+          </Text>
+          <View style={styles.summaryRow}>
+            <Text style={styles.summaryLabel}>Gains:</Text>
+            <Text style={[styles.summaryValue, { color: '#059669' }]}>
+              {formatCurrency(data.gainsBeforeRateChange)}
+            </Text>
+          </View>
+          <View style={styles.summaryRow}>
+            <Text style={styles.summaryLabel}>Losses:</Text>
+            <Text style={[styles.summaryValue, { color: '#dc2626' }]}>
+              ({formatCurrency(Math.abs(data.lossesBeforeRateChange))})
+            </Text>
+          </View>
+          <View style={[styles.summaryRow, { marginBottom: 8 }]}>
+            <Text style={styles.summaryLabel}>Net:</Text>
+            <Text
+              style={[
+                styles.summaryValue,
+                { color: data.netGainOrLossBeforeRateChange >= 0 ? '#059669' : '#dc2626' },
+              ]}
+            >
+              {formatCurrency(data.netGainOrLossBeforeRateChange)}
+            </Text>
+          </View>
+        </>
+      )}
+
+      {/* From 30 Oct section */}
+      <Text
+        style={{
+          fontSize: 9,
+          fontFamily: 'Helvetica-Bold',
+          color: '#92400e',
+          marginBottom: 4,
+          marginTop: data.gainsBeforeRateChange > 0 ? 4 : 0,
+          paddingTop: data.gainsBeforeRateChange > 0 ? 4 : 0,
+          borderTopWidth: data.gainsBeforeRateChange > 0 ? 1 : 0,
+          borderTopColor: '#fde68a',
+        }}
+      >
+        From 30 Oct 2024 ({data.newRates.basic}%/{data.newRates.higher}% rates)
+      </Text>
+      <View style={styles.summaryRow}>
+        <Text style={styles.summaryLabel}>Gains:</Text>
+        <Text style={[styles.summaryValue, { color: '#059669' }]}>
+          {formatCurrency(data.gainsAfterRateChange)}
+        </Text>
+      </View>
+      <View style={styles.summaryRow}>
+        <Text style={styles.summaryLabel}>Losses:</Text>
+        <Text style={[styles.summaryValue, { color: '#dc2626' }]}>
+          ({formatCurrency(Math.abs(data.lossesAfterRateChange))})
+        </Text>
+      </View>
+      <View style={styles.summaryRow}>
+        <Text style={styles.summaryLabel}>Net:</Text>
+        <Text
+          style={[
+            styles.summaryValue,
+            { color: data.netGainOrLossAfterRateChange >= 0 ? '#059669' : '#dc2626' },
+          ]}
+        >
+          {formatCurrency(data.netGainOrLossAfterRateChange)}
+        </Text>
+      </View>
+
+      <Text style={{ fontSize: 7, color: '#92400e', marginTop: 8 }}>
+        Use HMRC's calculator: gov.uk/guidance/work-out-your-capital-gains-tax-adjustment-for-the-2024-to-2025-tax-year
+      </Text>
+    </>
+  )
+}
+
+/**
+ * Content for when no Box 51 adjustment is required
+ */
+function NoAdjustmentRequiredContent({ data, context }: ContentProps): React.ReactElement {
+  const { Text, formatCurrency } = context
+
+  const message =
+    data.totalNetGainOrLoss <= data.annualExemptAmount
+      ? `Net gain (${formatCurrency(data.totalNetGainOrLoss)}) is below Annual Exempt Amount (${formatCurrency(data.annualExemptAmount)}). No CGT adjustment needed.`
+      : `All disposals were before 30 October 2024. No CGT adjustment needed.`
+
+  return <Text style={{ fontSize: 8, color: '#1e40af' }}>{message}</Text>
+}

--- a/src/lib/cgt/taxYearFeatures/pdfRenderers/index.ts
+++ b/src/lib/cgt/taxYearFeatures/pdfRenderers/index.ts
@@ -1,0 +1,54 @@
+/**
+ * PDF Renderer Registry for Tax Year Features
+ *
+ * Maps feature IDs to their PDF rendering functions.
+ * This registry enables the PDF export to dynamically render
+ * feature-specific sections without hardcoding each feature.
+ *
+ * To add a new feature's PDF renderer:
+ * 1. Create the renderer module in this directory
+ * 2. Import and add it to the PDF_RENDERERS map below
+ */
+
+import type { PDFRenderContext, FeaturePDFRenderer, TaxYearFeaturesMap } from '../types'
+import { renderCGTRateChange2024PDF } from './cgtRateChange2024PDF'
+
+/**
+ * Registry mapping feature IDs to their PDF renderer functions.
+ */
+const PDF_RENDERERS: Record<string, FeaturePDFRenderer<any>> = {
+  'cgt-rate-change-2024': renderCGTRateChange2024PDF,
+  // Future features can be added here, e.g.:
+  // 'cgt-rate-change-2028': renderCGTRateChange2028PDF,
+}
+
+/**
+ * Render all feature PDF sections for a given features map.
+ *
+ * Iterates through all features and calls their PDF renderers,
+ * returning an array of rendered elements.
+ *
+ * @param features - Map of feature ID to feature data
+ * @param context - PDF rendering context with components and styles
+ * @returns Array of rendered PDF elements
+ */
+export function renderAllFeaturePDFSections(
+  features: TaxYearFeaturesMap | undefined,
+  context: PDFRenderContext
+): React.ReactElement[] {
+  if (!features) return []
+
+  const elements: React.ReactElement[] = []
+
+  for (const [featureId, data] of Object.entries(features)) {
+    const renderer = PDF_RENDERERS[featureId]
+    if (renderer) {
+      const element = renderer(data, context)
+      if (element) {
+        elements.push(element)
+      }
+    }
+  }
+
+  return elements
+}

--- a/src/lib/cgt/taxYearFeatures/registry.ts
+++ b/src/lib/cgt/taxYearFeatures/registry.ts
@@ -86,9 +86,3 @@ export function hasApplicableFeatures(taxYear: string): boolean {
 export function getAllFeatureIds(): string[] {
   return TAX_YEAR_FEATURES.map((feature) => feature.id)
 }
-
-// Re-export types for convenience
-export type { TaxYearFeature, TaxYearFeatureData, TaxYearFeaturesMap } from './types'
-
-// Re-export specific feature data types
-export type { CGTRateChange2024Data } from './cgtRateChange2024'

--- a/src/lib/cgt/taxYearFeatures/types.ts
+++ b/src/lib/cgt/taxYearFeatures/types.ts
@@ -22,6 +22,30 @@ export interface TaxYearFeatureData {
 }
 
 /**
+ * PDF rendering context passed to feature PDF renderers.
+ * Contains react-pdf components and shared styles needed to render PDF sections.
+ */
+export interface PDFRenderContext {
+  /** react-pdf Text component */
+  Text: any
+  /** react-pdf View component */
+  View: any
+  /** Shared styles for the PDF document */
+  styles: any
+  /** Currency formatter */
+  formatCurrency: (value: number) => string
+}
+
+/**
+ * Function type for rendering a feature's PDF section.
+ * Returns null if the feature has nothing to render.
+ */
+export type FeaturePDFRenderer<TData extends TaxYearFeatureData> = (
+  data: TData,
+  context: PDFRenderContext
+) => React.ReactElement | null
+
+/**
  * A tax year feature that can calculate data and be rendered in UI/PDF.
  *
  * @template TData - The shape of data this feature produces

--- a/src/types/cgt.ts
+++ b/src/types/cgt.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { EnrichedTransaction, GainGroup } from './transaction'
+import type { TaxYearFeaturesMap } from '../lib/cgt/taxYearFeatures/types'
 
 /**
  * CGT Calculation Types
@@ -135,7 +136,7 @@ export interface TaxYearSummary {
    * Example: For 2024/25, this may contain:
    * { 'cgt-rate-change-2024': CGTRateChange2024Data }
    */
-  features?: Record<string, unknown>
+  features?: TaxYearFeaturesMap
 }
 
 /**


### PR DESCRIPTION
## Summary

- Abstract PDF exporter from tax year feature specifics using a registry pattern
- Add PDFRenderContext and FeaturePDFRenderer types to the features system
- Create PDF renderer registry mapping feature IDs to render functions
- Move 2024 CGT rate change PDF rendering to dedicated module
- Replace 65 lines of hardcoded rendering in PDFExport.tsx with 4-line feature-based call

## Benefits

- **Extensibility**: Adding future tax year features only requires creating a new renderer and registering it
- **Separation of concerns**: Each feature owns its PDF rendering logic
- **Type safety**: Features property now uses TaxYearFeaturesMap instead of Record<string, unknown>
- **Maintainability**: PDFExport.tsx is now feature-agnostic

## Test plan

- [x] Build passes (npm run build)
- [x] All 456 unit tests pass (npm test)
- [ ] Manually verify PDF export still works for 2024/25 tax year with CGT rate change feature

https://claude.ai/code/session_01BWVFUxBZDNkv5y5bhiyd3M