### PR TITLE
fix: map IB transaction types to proper categories instead of UNKNOWN

### DIFF
--- a/src/lib/csvParser.ts
+++ b/src/lib/csvParser.ts
@@ -132,7 +132,7 @@ export async function preprocessInteractiveBrokersCSV(file: File): Promise<File>
           } else if (sectionName === 'Summary') {
             // Also include Summary section for base currency extraction
             // Pad with empty columns to match Transaction History column count
-            summaryRows.push(`${sectionName},${rowType},${restOfLine},,,,,,,,`)
+            summaryRows.push(`${sectionName},${rowType},${restOfLine},,,,,,,,,`)
           }
         }
       }

--- a/src/lib/parsers/__tests__/interactiveBrokers.test.ts
+++ b/src/lib/parsers/__tests__/interactiveBrokers.test.ts
@@ -149,9 +149,9 @@ describe('Interactive Brokers Parser', () => {
 
       const result = normalizeInteractiveBrokersTransactions(rows, 'test-file')
 
-      expect(result).toHaveLength(4) // Adjustment (UNKNOWN), Deposit, Withdrawal, and Buy
-      expect(result[0].type).toBe(TransactionType.UNKNOWN)
-      expect(result[0].notes).toBe('Unrecognized transaction type: Adjustment')
+      expect(result).toHaveLength(4) // Adjustment (FEE), Deposit, Withdrawal, and Buy
+      expect(result[0].type).toBe(TransactionType.FEE)
+      expect(result[0].notes).toBe('Adjustment')
       expect(result[1].type).toBe(TransactionType.TRANSFER)
       expect(result[1].notes).toBe('Deposit')
       expect(result[2].type).toBe(TransactionType.TRANSFER)

--- a/src/lib/parsers/interactiveBrokers.ts
+++ b/src/lib/parsers/interactiveBrokers.ts
@@ -12,9 +12,19 @@ const TRADE_TYPES = new Set(['Buy', 'Sell', 'Assignment'])
 const INTEREST_TYPES = new Set(['Credit Interest', 'Debit Interest', 'Investment Interest Paid', 'Investment Interest Received'])
 
 /**
- * Transaction types from IB for transfers (deposits/withdrawals)
+ * Transaction types from IB for transfers (deposits/withdrawals, FX conversions)
  */
-const TRANSFER_TYPES = new Set(['Deposit', 'Withdrawal', 'Transfer'])
+const TRANSFER_TYPES = new Set(['Deposit', 'Withdrawal', 'Transfer', 'Forex Trade Component'])
+
+/**
+ * Transaction types from IB for fees (subscriptions, withdrawal fees, FX adjustments)
+ */
+const FEE_TYPES = new Set(['Other Fee', 'Adjustment'])
+
+/**
+ * Transaction types from IB for taxes (VAT on subscriptions)
+ */
+const TAX_TYPES = new Set(['Sales Tax'])
 
 /**
  * Parse gross amount from IB row (handles column name with trailing space)
@@ -149,11 +159,57 @@ function normalizeIBTransactionHistoryRow(
     return normalizeInterestRow(row, fileId, rowIndex, baseCurrency, transactionType, date, description)
   }
 
-  // Handle transfer transactions (deposits, withdrawals)
-  if (TRANSFER_TYPES.has(transactionType)) {
+  // Handle foreign tax withholding (tax on dividends)
+  if (transactionType === 'Foreign Tax Withholding') {
+    const symbol = row['Symbol']?.trim() || 'CASH'
+    if (symbol === '-') return null
+    return {
+      ...createBaseTransaction(fileId, rowIndex, baseCurrency, date, description),
+      symbol,
+      type: TransactionType.TAX_ON_DIVIDEND,
+      quantity: null,
+      price: null,
+      total: parseGrossAmount(row),
+      fee: null,
+      notes: 'Foreign Tax Withholding',
+    }
+  }
+
+  // Handle fee transactions (subscription fees, withdrawal fees, FX adjustments)
+  if (FEE_TYPES.has(transactionType)) {
+    const symbol = row['Symbol']?.trim()
+    return {
+      ...createBaseTransaction(fileId, rowIndex, baseCurrency, date, description),
+      symbol: (symbol && symbol !== '-') ? symbol : 'CASH',
+      type: TransactionType.FEE,
+      quantity: null,
+      price: null,
+      total: parseGrossAmount(row),
+      fee: null,
+      notes: transactionType,
+    }
+  }
+
+  // Handle tax transactions (VAT on subscriptions)
+  if (TAX_TYPES.has(transactionType)) {
     return {
       ...createBaseTransaction(fileId, rowIndex, baseCurrency, date, description),
       symbol: 'CASH',
+      type: TransactionType.TAX,
+      quantity: null,
+      price: null,
+      total: parseGrossAmount(row),
+      fee: null,
+      notes: transactionType,
+    }
+  }
+
+  // Handle transfer transactions (deposits, withdrawals, FX conversions)
+  if (TRANSFER_TYPES.has(transactionType)) {
+    const symbol = row['Symbol']?.trim()
+    return {
+      ...createBaseTransaction(fileId, rowIndex, baseCurrency, date, description),
+      symbol: (symbol && symbol !== '-') ? symbol : 'CASH',
       type: TransactionType.TRANSFER,
       quantity: null,
       price: null,


### PR DESCRIPTION
## Summary
- Map 5 Interactive Brokers transaction types that were falling through to UNKNOWN: `Foreign Tax Withholding` → TAX_ON_DIVIDEND, `Other Fee`/`Adjustment` → FEE, `Sales Tax` → TAX, `Forex Trade Component` → TRANSFER
- Fix IB CSV preprocessing: Summary rows were padded to 12 fields instead of 13 (missing `Price Currency` column), causing PapaParse "Too few fields" errors on import

## Test plan
- [x] All 479 unit tests pass
- [x] Build succeeds with no TypeScript errors
- [ ] Re-import an IB CSV — no more UNKNOWN transaction types
- [ ] Verify Foreign Tax Withholding rows show as TAX_ON_DIVIDEND
- [ ] Verify Forex Trade Component rows show as TRANSFER

🤖 Generated with [Claude Code](https://claude.com/claude-code)