### PR TITLE
fix: gate Claude Code Review for external contributors via label

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,10 +2,18 @@ name: Claude Code Review
 
 on:
   pull_request_target:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize, ready_for_review, reopened, labeled]
 
 jobs:
   claude-review:
+    # Run automatically for collaborators/members/owners.
+    # For external contributors, a maintainer must add the 'claude-review' label.
+    if: >-
+      (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
+      (github.event.action != 'labeled' &&
+       (github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'COLLABORATOR'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Run the review automatically for repo owners/members/collaborators.
For external contributors, require a maintainer to add the
'claude-review' label, which ensures the actor has write permissions.

Fixes the "Actor does not have write permissions" error on fork PRs.

https://claude.ai/code/session_015Zhh41vjtvr5btepBtwK24