### PR TITLE
fix: IB parser follow-ups from PR #57/#58 review

### DIFF
--- a/src/lib/parsers/interactiveBrokers.ts
+++ b/src/lib/parsers/interactiveBrokers.ts
@@ -235,11 +235,10 @@ function normalizeIBTransactionHistoryRow(
 
   // Handle foreign tax withholding (tax on dividends)
   if (transactionType === 'Foreign Tax Withholding') {
-    const symbol = row['Symbol']?.trim() || 'CASH'
-    if (symbol === '-') return null
+    const symbol = row['Symbol']?.trim()
     return {
       ...createBaseTransaction(fileId, rowIndex, baseCurrency, date, description),
-      symbol,
+      symbol: (symbol && symbol !== '-') ? symbol : 'CASH',
       type: TransactionType.TAX_ON_DIVIDEND,
       quantity: null,
       price: null,
@@ -341,6 +340,10 @@ function normalizeTradeRow(
   if (isIBOptionsSymbol(symbol)) {
     const parsed = parseIBOptionsSymbol(symbol)
     if (!parsed) return null
+
+    // Guard against misclassification: Assignment has no quantity column in IB exports,
+    // but Buy/Sell rows with unparseable quantity would otherwise fall into the selling branch below
+    if (rawQuantity === null && transactionType !== 'Assignment') return null
 
     // Determine options transaction type using position tracking
     const currentPosition = optionsPositions.get(symbol) || 0


### PR DESCRIPTION
## Summary
Addresses post-merge review comments on PRs #57 and #58.

- Map `Foreign Tax Withholding` rows with `symbol='-'` to `'CASH'` instead of silently dropping them, matching the convention used by other IB handlers (#57 follow-up).
- Guard the options branch against `null` `rawQuantity` so unparseable quantities aren't misclassified as `OPTIONS_SELL_TO_OPEN` (#58 follow-up).

Other review notes were intentionally skipped: WHT double-counting is speculative pending real data; the `TransactionType` type nit doesn't apply since it's a const object (not an enum); `new Date()` and ID-stability concerns are design preferences rather than bugs. Broader test coverage gaps are worth a separate PR.

## Test plan
- [x] `npm run build`
- [x] `npx vitest run src/lib/parsers/__tests__/interactiveBrokers.test.ts`
- [ ] Manual: import an IB CSV with a `Foreign Tax Withholding` summary row (`symbol='-'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)