### PR TITLE
ci: run build, unit, and e2e tests on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-unit:
+    name: Build and unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Unit tests
+        run: npm test
+
+  e2e:
+    name: E2E tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
 
   e2e:
     name: E2E tests
+    needs: build-and-unit
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` which runs on every PR and push to main:

- **Build and unit tests** job — `npm ci`, `npm run build`, `npm test`
- **E2E tests** job — installs Playwright chromium, runs `npm run test:e2e`, uploads the Playwright report + test-results on failure

## Why

There was previously no CI workflow that ran tests — only Claude review bots and the GitHub Pages deploy. That's how the IB example import regression from PR #57 shipped unnoticed (tracked in #61).

## Notes

- Uses Node 20 to match `deploy.yml`.
- Uses `concurrency` to cancel stale runs on the same ref when a new push arrives.
- E2E job uploads `playwright-report/` and `test-results/` as artifacts only on failure (7-day retention) to help debug failing runs without bloating storage.
- Known caveat: this CI will currently fail on `main` until issue #61 (IB example file) is addressed, because the IB example import e2e test is broken. Worth keeping in mind when reviewing.

## Test plan
- [x] Confirm both jobs run and pass (or, for the IB e2e, fail in the expected way linked to #61)
- [ ] Confirm artifacts upload when the e2e job fails