### PR TITLE
Include incomplete disposals in "Needs attention" filter (issue #68)

### DIFF
--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useTransactionStore } from '../stores/transactionStore'
 import { ClearDataButton } from './ClearDataButton'
 import { Tooltip } from './Tooltip'
@@ -38,6 +38,7 @@ export function TransactionList() {
   const transactions = useTransactionStore((state) => state.transactions)
   const isLoading = useTransactionStore((state) => state.isLoading)
   const getDisposals = useTransactionStore((state) => state.getDisposals)
+  const cgtResults = useTransactionStore((state) => state.cgtResults)
   const getSection104Pools = useTransactionStore((state) => state.getSection104Pools)
   const toggleHelpPanelWithContext = useTransactionStore((state) => state.toggleHelpPanelWithContext)
   const [showFxInfo, setShowFxInfo] = useState(false)
@@ -96,8 +97,9 @@ export function TransactionList() {
   // disposal). The filter below lets users jump straight to these rows instead
   // of scrolling. The disposal set mirrors the Issues panel (useIssues), which
   // flags disposals where `isIncomplete` is true.
-  const incompleteDisposalIds = new Set(
-    disposals.filter(d => d.isIncomplete).map(d => d.disposal.id)
+  const incompleteDisposalIds = useMemo(
+    () => new Set(cgtResults?.disposals.filter(d => d.isIncomplete).map(d => d.disposal.id)),
+    [cgtResults]
   )
   const needsAttention = (tx: typeof transactions[number]) =>
     Boolean(tx.incomplete || tx.fx_error || incompleteDisposalIds.has(tx.id))

--- a/src/components/TransactionList.tsx
+++ b/src/components/TransactionList.tsx
@@ -91,10 +91,16 @@ export function TransactionList() {
   })
 
   // A transaction "needs attention" if it is missing required data (e.g. Schwab
-  // Stock Plan Activity without price) or failed FX conversion. The filter below
-  // lets users jump straight to these rows instead of scrolling.
+  // Stock Plan Activity without price), failed FX conversion, or is a disposal
+  // that the CGT engine could not fully match to acquisitions (incomplete
+  // disposal). The filter below lets users jump straight to these rows instead
+  // of scrolling. The disposal set mirrors the Issues panel (useIssues), which
+  // flags disposals where `isIncomplete` is true.
+  const incompleteDisposalIds = new Set(
+    disposals.filter(d => d.isIncomplete).map(d => d.disposal.id)
+  )
   const needsAttention = (tx: typeof transactions[number]) =>
-    Boolean(tx.incomplete || tx.fx_error)
+    Boolean(tx.incomplete || tx.fx_error || incompleteDisposalIds.has(tx.id))
   const attentionCount = transactions.filter(needsAttention).length
 
   // Apply the active filter to decide which rows to render


### PR DESCRIPTION
## Problem
When testing with a real Schwab file, the Issues panel showed two categories — **8 "incomplete disposal data"** + **43 incomplete stock plan activity** — but the "Needs attention" filter only surfaced the **43**, missing the **8** disposals.

## Cause
`needsAttention` only matched transaction-level flags (`tx.incomplete || tx.fx_error`). "Incomplete disposals" aren't a flag on the transaction — they're computed by the CGT engine (`DisposalRecord.isIncomplete`: a SELL that couldn't be fully matched to acquisitions). So those rows were never caught by the filter even though the Issues panel flags them.

## Fix
Add disposals where `isIncomplete` is true to the filter, keyed by the disposal transaction id — mirroring the `useIssues` hook (`useIssues.ts`), which is the same source the Issues panel uses. The filter and its count badge now align with the Issues panel (43 + 8 = 51 in the reported case).

## Testing
- `npm run build` ✓
- `npm test` — 504 passed ✓
- Verified with the `freetrade-example.csv` fixture (which produces incomplete disposals with no FX dependency): the 3 incomplete-disposal SELL rows now appear in the filtered list with their red "Incomplete" badges and are counted in the badge. Screenshot shared with the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GZFtGjhp3MpheAKKEWJGLu

---
_Generated by [Claude Code](https://claude.ai/code/session_01GZFtGjhp3MpheAKKEWJGLu)_