### PR TITLE
Fix Trading 212 GBX currency imports

### DIFF
--- a/src/config/brokers/trading212.ts
+++ b/src/config/brokers/trading212.ts
@@ -1,6 +1,32 @@
-import { BrokerType } from '../../types/broker'
+import { BrokerType, RawCSVRow } from '../../types/broker'
 import { BrokerDefinition } from '../../types/brokerDefinition'
 import { normalizeTrading212Transactions } from '../../lib/parsers/trading212'
+
+function detectTrading212Headers(headers: string[], rows: RawCSVRow[]) {
+  void rows
+  const normalizedHeaders = headers.map(header => header.trim())
+  const hasAction = normalizedHeaders.includes('Action')
+  const hasTime = normalizedHeaders.includes('Time') || normalizedHeaders.includes('Time (UTC)')
+  const hasIsin = normalizedHeaders.includes('ISIN')
+  const hasTicker = normalizedHeaders.includes('Ticker')
+  const hasShares = normalizedHeaders.includes('No. of shares') || normalizedHeaders.includes('Quantity')
+  const hasTotal = normalizedHeaders.includes('Total')
+
+  const matchedHeaders = [
+    hasAction ? 'Action' : null,
+    hasTime ? 'Time' : null,
+    hasIsin ? 'ISIN' : null,
+    hasTicker ? 'Ticker' : null,
+    hasShares ? 'No. of shares' : null,
+    hasTotal ? 'Total' : null,
+  ].filter((header): header is string => header !== null)
+
+  return {
+    broker: BrokerType.TRADING212,
+    confidence: matchedHeaders.length / 6,
+    headerMatches: matchedHeaders,
+  }
+}
 
 export const trading212Definition: BrokerDefinition = {
   type: BrokerType.TRADING212,
@@ -9,6 +35,7 @@ export const trading212Definition: BrokerDefinition = {
   detection: {
     requiredHeaders: ['Action', 'Time', 'ISIN', 'Ticker', 'No. of shares'],
     priority: 50,
+    customDetector: detectTrading212Headers,
   },
   parser: normalizeTrading212Transactions,
   instructions: {

--- a/src/lib/__tests__/brokerDetector.test.ts
+++ b/src/lib/__tests__/brokerDetector.test.ts
@@ -66,6 +66,26 @@ describe('brokerDetector', () => {
       expect(result.confidence).toBeGreaterThan(0.8)
     })
 
+    it('should detect Trading 212 format with the newer Time (UTC) header', () => {
+      const trading212Rows = [
+        {
+          'Action': 'Market buy',
+          'Time (UTC)': '2025-07-16 08:39:58+00:00',
+          'Ticker': 'RR',
+          'No. of shares': '25.9686809800',
+          'Total': '260.00',
+        },
+      ]
+
+      const result = detectBroker(trading212Rows)
+
+      expect(result.broker).toBe(BrokerType.TRADING212)
+      expect(result.confidence).toBeGreaterThan(0.8)
+      expect(result.headerMatches).toContain('Action')
+      expect(result.headerMatches).toContain('Time')
+      expect(result.headerMatches).toContain('Ticker')
+    })
+
     it('should prefer Schwab over Trading212 when Schwab has higher confidence', () => {
       const mixedRows = [
         {

--- a/src/lib/parsers/__tests__/trading212.test.ts
+++ b/src/lib/parsers/__tests__/trading212.test.ts
@@ -47,6 +47,45 @@ describe('Trading 212 Parser', () => {
       })
     })
 
+    it('should normalize a buy transaction from the newer Trading 212 export format', () => {
+      const rows = [
+        {
+          'Action': 'Market buy',
+          'Time (UTC)': '2025-07-16 08:39:58+00:00',
+          'Ticker': 'RR',
+          'Name': 'Rolls-Royce',
+          'No. of shares': '25.9686809800',
+          'Price / share': '996.2000000000',
+          'Currency (Price / share)': 'GBX',
+          'Total': '260.00',
+          'Currency (Total)': 'GBP',
+          'Stamp duty reserve tax': '1.30',
+          'Currency (Stamp duty reserve tax)': 'GBP',
+          'Currency conversion fee': '',
+          'Currency (Currency conversion fee)': '',
+          'Notes': '',
+          'ID': 'EOF35712623564',
+        },
+      ]
+
+      const result = normalizeTrading212Transactions(rows, 'test-file')
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        id: 'test-file-1',
+        source: 'Trading 212',
+        symbol: 'RR',
+        name: 'Rolls-Royce',
+        date: '2025-07-16',
+        type: TransactionType.BUY,
+        quantity: 25.9686809800,
+        price: 9.962,
+        currency: 'GBP',
+        total: 25.9686809800 * 9.962,
+        fee: 1.3,
+      })
+    })
+
     it('should normalize a Limit sell transaction', () => {
       const rows = [
         {

--- a/src/lib/parsers/trading212.ts
+++ b/src/lib/parsers/trading212.ts
@@ -34,6 +34,28 @@ import { parseNumber } from './parsingUtils'
 
 type TransactionTypeValue = typeof TransactionType[keyof typeof TransactionType]
 
+const HEADER_LOOKUPS = {
+  time: ['Time', 'Time (UTC)'],
+  quantity: ['No. of shares'],
+  price: ['Price / share'],
+  priceCurrency: ['Currency (Price / share)'],
+  transactionFee: ['Transaction fee', 'Stamp duty reserve tax'],
+  currencyConversionFee: ['Currency conversion fee'],
+  withholdingTax: ['Withholding tax'],
+  withholdingTaxCurrency: ['Currency (Withholding tax)'],
+} as const
+
+function getRowValue(row: RawCSVRow, headers: readonly string[]): string | undefined {
+  for (const header of headers) {
+    const value = row[header]
+    if (value !== undefined && value !== null && value !== '') {
+      return value
+    }
+  }
+
+  return undefined
+}
+
 /**
  * Exact match mappings for Trading 212 actions
  */
@@ -97,7 +119,7 @@ export function normalizeTrading212Transactions(
   return rows
     .map((row, index) => {
       const action = row['Action']
-      const time = row['Time']
+      const time = getRowValue(row, HEADER_LOOKUPS.time)
       const ticker = row['Ticker']
       const name = row['Name']
 
@@ -107,12 +129,12 @@ export function normalizeTrading212Transactions(
       const type = mapActionToType(action)
 
       // Parse numeric fields
-      const quantity = parseNumber(row['No. of shares'])
-      const price = parseNumber(row['Price / share'])
+      const quantity = parseNumber(getRowValue(row, HEADER_LOOKUPS.quantity))
+      const price = parseNumber(getRowValue(row, HEADER_LOOKUPS.price))
       const csvTotal = parseNumber(row['Total'])
-      const transactionFee = parseNumber(row['Transaction fee'])
-      const currencyConversionFee = parseNumber(row['Currency conversion fee'])
-      const withholdingTax = parseNumber(row['Withholding tax'])
+      const transactionFee = parseNumber(getRowValue(row, HEADER_LOOKUPS.transactionFee))
+      const currencyConversionFee = parseNumber(getRowValue(row, HEADER_LOOKUPS.currencyConversionFee))
+      const withholdingTax = parseNumber(getRowValue(row, HEADER_LOOKUPS.withholdingTax))
 
       // Combine all fees
       let fee: number | undefined
@@ -120,24 +142,28 @@ export function normalizeTrading212Transactions(
         fee = (transactionFee || 0) + (currencyConversionFee || 0)
       }
 
-      // Get currencies - use price currency as the transaction currency
-      // Trading 212 stores the original price in its native currency,
-      // and converts total to account currency (usually GBP)
-      const priceCurrency = row['Currency (Price / share)']
+      // Get currencies - use price currency as the transaction currency.
+      // Trading 212 quotes UK-listed securities in GBX (pence), which must
+      // be normalised to GBP before FX enrichment.
+      const priceCurrency = getRowValue(row, HEADER_LOOKUPS.priceCurrency)
       const totalCurrency = row['Currency (Total)']
+      const isPenceQuoted = priceCurrency?.toUpperCase() === 'GBX'
+      const normalizedPrice = isPenceQuoted && price !== undefined
+        ? price / 100
+        : price
 
       // The transaction currency should be the price currency (e.g., USD for US stocks)
       // NOT the total currency (which is the account currency after conversion)
-      const currency = priceCurrency || totalCurrency || 'GBP'
+      const currency = isPenceQuoted ? 'GBP' : priceCurrency || totalCurrency || 'GBP'
 
       // For BUY/SELL: Calculate total from price × quantity in the original currency
       // For others (DIVIDEND, INTEREST, TRANSFER): Use the CSV total (already in correct currency)
       let total: number | null
       if (type === 'BUY' || type === 'SELL') {
         // Calculate from price × quantity for buy/sell transactions
-        total = price !== undefined && price !== null &&
+        total = normalizedPrice !== undefined && normalizedPrice !== null &&
                 quantity !== undefined && quantity !== null
-          ? price * quantity
+          ? normalizedPrice * quantity
           : null
       } else {
         // Use CSV total for non-trading transactions (dividends, interest, transfers)
@@ -152,7 +178,7 @@ export function normalizeTrading212Transactions(
         symbol: ticker || '',
         name: name || null,
         quantity: quantity ?? null,
-        price: price ?? null,
+        price: normalizedPrice ?? null,
         currency,
         total,
         fee: fee ?? null,
@@ -162,7 +188,7 @@ export function normalizeTrading212Transactions(
       // For dividend transactions, calculate gross dividend and store withholding tax
       // Gross = Net (total) + Withholding Tax
       if (type === 'DIVIDEND') {
-        const taxCurrency = row['Currency (Withholding tax)'] || currency
+        const taxCurrency = getRowValue(row, HEADER_LOOKUPS.withholdingTaxCurrency) || currency
           
         // Calculate gross dividend: total (net) + withholding tax
         const grossDividend = withholdingTax && total !== null
@@ -182,7 +208,7 @@ export function normalizeTrading212Transactions(
         }
       } else if (withholdingTax && withholdingTax > 0) {
         // For non-dividend transactions with withholding tax, just add to notes
-        const taxCurrency = row['Currency (Withholding tax)'] || currency
+        const taxCurrency = getRowValue(row, HEADER_LOOKUPS.withholdingTaxCurrency) || currency
         const taxNote = `Withholding tax: ${withholdingTax} ${taxCurrency}`
         transaction.notes = transaction.notes
           ? `${transaction.notes}; ${taxNote}`


### PR DESCRIPTION
## Summary

Adds support for Trading 212's newer CSV export format.

- Detects the `Time (UTC)` header used by newer exports
- Supports `Stamp duty reserve tax` in place of the older transaction-fee column
- Normalizes UK `GBX` (pence) prices to GBP so they are not treated as unsupported currencies
- Adds regression tests for detection and parsing of the newer format

## Why

Trading 212 exports UK-listed securities in GBX. Previously these transactions were reported as unsupported “crypto currencies”, preventing FX enrichment and CGT calculations.

## Verification

- `npm test -- --run src/lib/parsers/__tests__/trading212.test.ts`
- `npm run build`